### PR TITLE
Add aiogram bot core with i18n and middlewares

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ __pycache__/
 .env
 .coverage
 .mypy_cache/
+*.mo
 

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import os
 
-from aiogram import Bot, Dispatcher
+from aiogram import Bot
 from aiogram.types import Update
 from fastapi import APIRouter, FastAPI
+
+from app.bot import dp
 
 ALLOWED_UPDATES = [
     "message",
@@ -17,7 +19,6 @@ router = APIRouter()
 
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
 bot: Bot | None = Bot(TELEGRAM_TOKEN) if TELEGRAM_TOKEN else None
-dp = Dispatcher()
 
 
 @router.get("/health")

--- a/app/bot/__init__.py
+++ b/app/bot/__init__.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import run
+
+from aiogram import Dispatcher
+from aiogram.fsm.storage.memory import MemoryStorage
+from aiogram.utils.i18n import I18n, SimpleI18nMiddleware
+
+from .handlers import router
+from .middlewares import AntiFloodMiddleware, UserParallelLimitMiddleware
+
+__all__ = ["dp", "i18n"]
+
+# Internationalization
+locales_dir = Path(__file__).parent / "locales"
+for po_file in locales_dir.glob("*/LC_MESSAGES/*.po"):
+    mo_file = po_file.with_suffix(".mo")
+    if not mo_file.exists():
+        run(["msgfmt", str(po_file), "-o", str(mo_file)], check=True)
+i18n = I18n(path=locales_dir, default_locale="en", domain="bot")
+
+# Dispatcher with FSM storage and middlewares
+storage = MemoryStorage()
+dp = Dispatcher(storage=storage)
+
+i18n_middleware = SimpleI18nMiddleware(i18n)
+# Register middlewares
+for m in (
+    AntiFloodMiddleware(),
+    UserParallelLimitMiddleware(limit=2),
+    i18n_middleware,
+):
+    dp.update.middleware.register(m)
+
+# Include handlers
+dp.include_router(router)

--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from aiogram import F, Router
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import CallbackQuery, Message
+from aiogram.utils.i18n import gettext as _
+
+from .menu import main_menu
+
+router = Router()
+
+
+class MainState(StatesGroup):
+    menu = State()
+
+
+@router.message(Command("start"))
+async def cmd_start(message: Message, state: FSMContext) -> None:
+    await state.set_state(MainState.menu)
+    await message.answer(
+        _("Welcome! Use the menu below to choose an expert or view tariffs."),
+        reply_markup=main_menu(),
+    )
+
+
+@router.message(Command("help"))
+async def cmd_help(message: Message) -> None:
+    await message.answer(
+        _(
+            "Help: This bot provides astrological readings and other services. "
+            "Use the menu or commands."
+        )
+    )
+
+
+@router.message(Command("profile"))
+async def cmd_profile(message: Message) -> None:
+    await message.answer(_("Profile: no data available."))
+
+
+@router.message(Command("history"))
+async def cmd_history(message: Message) -> None:
+    await message.answer(_("History: no records."))
+
+
+@router.callback_query(F.data == "profile")
+async def cb_profile(callback: CallbackQuery) -> None:
+    if callback.message:
+        await callback.message.answer(_("Profile: no data available."))
+    await callback.answer()
+
+
+@router.callback_query(F.data == "tariffs")
+async def cb_tariffs(callback: CallbackQuery) -> None:
+    if callback.message:
+        await callback.message.answer(_("History: no records."))
+    await callback.answer()

--- a/app/bot/locales/en/LC_MESSAGES/bot.po
+++ b/app/bot/locales/en/LC_MESSAGES/bot.po
@@ -1,0 +1,46 @@
+msgid ""
+msgstr ""
+"Language: en\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "Welcome! Use the menu below to choose an expert or view tariffs."
+msgstr "Welcome! Use the menu below to choose an expert or view tariffs."
+
+msgid "Help: This bot provides astrological readings and other services. Use the menu or commands."
+msgstr "Help: This bot provides astrological readings and other services. Use the menu or commands."
+
+msgid "Profile: no data available."
+msgstr "Profile: no data available."
+
+msgid "History: no records."
+msgstr "History: no records."
+
+msgid "🃏 Tarot"
+msgstr "🃏 Tarot"
+
+msgid "♣ Lenormand"
+msgstr "♣ Lenormand"
+
+msgid "ᚱ Runes"
+msgstr "ᚱ Runes"
+
+msgid "✨ Astrology"
+msgstr "✨ Astrology"
+
+msgid "🌙 Dreams"
+msgstr "🌙 Dreams"
+
+msgid "✍️ Copywriter"
+msgstr "✍️ Copywriter"
+
+msgid "🤖 Assistant"
+msgstr "🤖 Assistant"
+
+msgid "🔢 Numerology"
+msgstr "🔢 Numerology"
+
+msgid "💎 Premium/Payment"
+msgstr "💎 Premium/Payment"
+
+msgid "👤 Profile/History"
+msgstr "👤 Profile/History"

--- a/app/bot/locales/ru/LC_MESSAGES/bot.po
+++ b/app/bot/locales/ru/LC_MESSAGES/bot.po
@@ -1,0 +1,46 @@
+msgid ""
+msgstr ""
+"Language: ru\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "Welcome! Use the menu below to choose an expert or view tariffs."
+msgstr "Добро пожаловать! Используйте меню ниже, чтобы выбрать эксперта или тариф."
+
+msgid "Help: This bot provides astrological readings and other services. Use the menu or commands."
+msgstr "Помощь: этот бот предоставляет астрологические и другие консультации. Используйте меню или команды."
+
+msgid "Profile: no data available."
+msgstr "Профиль: данные отсутствуют."
+
+msgid "History: no records."
+msgstr "История: записей нет."
+
+msgid "🃏 Tarot"
+msgstr "🃏 Таролог"
+
+msgid "♣ Lenormand"
+msgstr "♣ Ленорман"
+
+msgid "ᚱ Runes"
+msgstr "ᚱ Рунолог"
+
+msgid "✨ Astrology"
+msgstr "✨ Астролог"
+
+msgid "🌙 Dreams"
+msgstr "🌙 Сны"
+
+msgid "✍️ Copywriter"
+msgstr "✍️ Копирайтер"
+
+msgid "🤖 Assistant"
+msgstr "🤖 Ассистент"
+
+msgid "🔢 Numerology"
+msgstr "🔢 Нумеролог"
+
+msgid "💎 Premium/Payment"
+msgstr "💎 Премиум/Оплата"
+
+msgid "👤 Profile/History"
+msgstr "👤 Профиль/История"

--- a/app/bot/menu.py
+++ b/app/bot/menu.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from aiogram.types import InlineKeyboardMarkup
+from aiogram.utils.i18n import gettext as _
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+EXPERT_BUTTONS = [
+    ("🃏 Tarot", "expert:tarot"),
+    ("♣ Lenormand", "expert:lenormand"),
+    ("ᚱ Runes", "expert:runes"),
+    ("✨ Astrology", "expert:astrology"),
+    ("🌙 Dreams", "expert:dreams"),
+    ("✍️ Copywriter", "expert:copywriter"),
+    ("🤖 Assistant", "expert:assistant"),
+    ("🔢 Numerology", "expert:numerology"),
+]
+
+TARIFF_BUTTON = ("💎 Premium/Payment", "tariffs")
+PROFILE_BUTTON = ("👤 Profile/History", "profile")
+
+
+def main_menu() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    for text, callback in EXPERT_BUTTONS:
+        builder.button(text=_(text), callback_data=callback)
+    builder.button(text=_(TARIFF_BUTTON[0]), callback_data=TARIFF_BUTTON[1])
+    builder.button(text=_(PROFILE_BUTTON[0]), callback_data=PROFILE_BUTTON[1])
+    builder.adjust(2)
+    return builder.as_markup()

--- a/app/bot/middlewares.py
+++ b/app/bot/middlewares.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import defaultdict
+from typing import Any, Awaitable, Callable, Dict
+
+from aiogram.dispatcher.middlewares.base import BaseMiddleware
+from aiogram.types import TelegramObject
+
+
+class AntiFloodMiddleware(BaseMiddleware):
+    """Simple anti-flood middleware limiting messages rate."""
+
+    def __init__(self, rate: float = 1.0) -> None:
+        super().__init__()
+        self.rate = rate
+        self._last_message: Dict[int, float] = {}
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, Dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: Dict[str, Any],
+    ) -> Any:
+        from_user = data.get("event_from_user")
+        if from_user:
+            now = time.monotonic()
+            last_time = self._last_message.get(from_user.id, 0.0)
+            if now - last_time < self.rate:
+                return None
+            self._last_message[from_user.id] = now
+        return await handler(event, data)
+
+
+class UserParallelLimitMiddleware(BaseMiddleware):
+    """Limit number of parallel tasks per user."""
+
+    def __init__(self, limit: int = 2) -> None:
+        super().__init__()
+        self.limit = limit
+        self._locks: Dict[int, asyncio.Semaphore] = defaultdict(
+            lambda: asyncio.Semaphore(limit)
+        )
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, Dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: Dict[str, Any],
+    ) -> Any:
+        from_user = data.get("event_from_user")
+        if from_user:
+            lock = self._locks[from_user.id]
+            async with lock:
+                return await handler(event, data)
+        return await handler(event, data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ psycopg[binary]
 minio
 SQLAlchemy>=2.0
 alembic
+Babel


### PR DESCRIPTION
## Summary
- implement Telegram bot core with aiogram 3: FSM, i18n and custom middlewares
- provide main menu keyboard and handlers for /start, /help, /profile and /history commands
- integrate dispatcher with webhook endpoint
- compile translations at runtime and ignore binary message catalogs

## Testing
- `ruff check --fix app/bot app/api`
- `black app/bot app/api`
- `mypy --strict app/bot app/api`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aac82d4db0832f83465dcda7882191