### PR TITLE
feat: add plugin system and discovery

### DIFF
--- a/app/core/plugins/__init__.py
+++ b/app/core/plugins/__init__.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+import pkgutil
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Callable, Dict, Sequence
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Plugin:
+    """Contract for expert plugins."""
+
+    plugin_id: str
+    form_steps: Callable[[str], list[dict[str, Any]]]
+    prepare: Callable[[dict[str, Any]], dict[str, Any]]
+    compose: Callable[[dict[str, Any]], dict[str, Any]]
+    write: Callable[[dict[str, Any]], dict[str, Any]]
+    verify: Callable[[dict[str, Any]], bool]
+    cost: int
+    cta: Callable[[str], list[str]]
+    products_supported: Sequence[str]
+
+
+Registry = Dict[str, Plugin]
+_registry: Registry = {}
+
+
+def register(plugin: Plugin) -> None:
+    """Register a plugin instance."""
+
+    if plugin.plugin_id in _registry:
+        raise ValueError(f"Plugin '{plugin.plugin_id}' already registered")
+    _registry[plugin.plugin_id] = plugin
+
+
+def discover() -> Registry:
+    """Discover and load plugins from :mod:`app.experts`."""
+
+    if _registry:
+        return _registry
+
+    package = import_module("app.experts")
+    for _, name, _ in pkgutil.iter_modules(package.__path__):
+        module_name = f"{package.__name__}.{name}"
+        try:
+            module = import_module(module_name)
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("Failed to load plugin '%s': %s", module_name, exc)
+            continue
+        plugin = getattr(module, "plugin", None)
+        if isinstance(plugin, Plugin):
+            try:
+                register(plugin)
+            except ValueError:
+                log.warning("Duplicate plugin_id '%s'", plugin.plugin_id)
+        else:
+            log.debug("Module '%s' does not expose a plugin", module_name)
+    return _registry
+
+
+def available() -> list[str]:
+    """Return identifiers of all registered plugins."""
+
+    return sorted(discover().keys())
+
+
+__all__ = ["Plugin", "register", "discover", "available"]

--- a/app/core/plugins/__main__.py
+++ b/app/core/plugins/__main__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from . import available, discover
+
+
+def main() -> None:
+    """Print identifiers of all discovered plugins."""
+
+    discover()
+    for plugin_id in available():
+        print(plugin_id)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI utility
+    main()

--- a/app/experts/assistant/__init__.py
+++ b/app/experts/assistant/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.plugins import Plugin
+
+PLUGIN_ID = "assistant"
+
+
+def form_steps(locale: str) -> list[dict[str, Any]]:
+    return []
+
+
+def prepare(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def compose(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def write(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "tldr": "Assistant plugin response",
+        "sections": [],
+        "actions": [],
+        "disclaimers": [],
+    }
+
+
+def verify(data: dict[str, Any]) -> bool:
+    return True
+
+
+def cta(locale: str) -> list[str]:
+    return []
+
+
+plugin = Plugin(
+    plugin_id=PLUGIN_ID,
+    form_steps=form_steps,
+    prepare=prepare,
+    compose=compose,
+    write=write,
+    verify=verify,
+    cost=0,
+    cta=cta,
+    products_supported=("basic",),
+)

--- a/app/experts/astrology/__init__.py
+++ b/app/experts/astrology/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.plugins import Plugin
+
+PLUGIN_ID = "astrology"
+
+
+def form_steps(locale: str) -> list[dict[str, Any]]:
+    return []
+
+
+def prepare(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def compose(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def write(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "tldr": "Astrology plugin response",
+        "sections": [],
+        "actions": [],
+        "disclaimers": [],
+    }
+
+
+def verify(data: dict[str, Any]) -> bool:
+    return True
+
+
+def cta(locale: str) -> list[str]:
+    return []
+
+
+plugin = Plugin(
+    plugin_id=PLUGIN_ID,
+    form_steps=form_steps,
+    prepare=prepare,
+    compose=compose,
+    write=write,
+    verify=verify,
+    cost=0,
+    cta=cta,
+    products_supported=("basic",),
+)

--- a/app/experts/copywriter/__init__.py
+++ b/app/experts/copywriter/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.plugins import Plugin
+
+PLUGIN_ID = "copywriter"
+
+
+def form_steps(locale: str) -> list[dict[str, Any]]:
+    return []
+
+
+def prepare(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def compose(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def write(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "tldr": "Copywriter plugin response",
+        "sections": [],
+        "actions": [],
+        "disclaimers": [],
+    }
+
+
+def verify(data: dict[str, Any]) -> bool:
+    return True
+
+
+def cta(locale: str) -> list[str]:
+    return []
+
+
+plugin = Plugin(
+    plugin_id=PLUGIN_ID,
+    form_steps=form_steps,
+    prepare=prepare,
+    compose=compose,
+    write=write,
+    verify=verify,
+    cost=0,
+    cta=cta,
+    products_supported=("basic",),
+)

--- a/app/experts/dreams/__init__.py
+++ b/app/experts/dreams/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.plugins import Plugin
+
+PLUGIN_ID = "dreams"
+
+
+def form_steps(locale: str) -> list[dict[str, Any]]:
+    return []
+
+
+def prepare(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def compose(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def write(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "tldr": "Dreams plugin response",
+        "sections": [],
+        "actions": [],
+        "disclaimers": [],
+    }
+
+
+def verify(data: dict[str, Any]) -> bool:
+    return True
+
+
+def cta(locale: str) -> list[str]:
+    return []
+
+
+plugin = Plugin(
+    plugin_id=PLUGIN_ID,
+    form_steps=form_steps,
+    prepare=prepare,
+    compose=compose,
+    write=write,
+    verify=verify,
+    cost=0,
+    cta=cta,
+    products_supported=("basic",),
+)

--- a/app/experts/lenormand/__init__.py
+++ b/app/experts/lenormand/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.plugins import Plugin
+
+PLUGIN_ID = "lenormand"
+
+
+def form_steps(locale: str) -> list[dict[str, Any]]:
+    return []
+
+
+def prepare(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def compose(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def write(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "tldr": "Lenormand plugin response",
+        "sections": [],
+        "actions": [],
+        "disclaimers": [],
+    }
+
+
+def verify(data: dict[str, Any]) -> bool:
+    return True
+
+
+def cta(locale: str) -> list[str]:
+    return []
+
+
+plugin = Plugin(
+    plugin_id=PLUGIN_ID,
+    form_steps=form_steps,
+    prepare=prepare,
+    compose=compose,
+    write=write,
+    verify=verify,
+    cost=0,
+    cta=cta,
+    products_supported=("basic",),
+)

--- a/app/experts/numerology/__init__.py
+++ b/app/experts/numerology/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.plugins import Plugin
+
+PLUGIN_ID = "numerology"
+
+
+def form_steps(locale: str) -> list[dict[str, Any]]:
+    return []
+
+
+def prepare(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def compose(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def write(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "tldr": "Numerology plugin response",
+        "sections": [],
+        "actions": [],
+        "disclaimers": [],
+    }
+
+
+def verify(data: dict[str, Any]) -> bool:
+    return True
+
+
+def cta(locale: str) -> list[str]:
+    return []
+
+
+plugin = Plugin(
+    plugin_id=PLUGIN_ID,
+    form_steps=form_steps,
+    prepare=prepare,
+    compose=compose,
+    write=write,
+    verify=verify,
+    cost=0,
+    cta=cta,
+    products_supported=("basic",),
+)

--- a/app/experts/runes/__init__.py
+++ b/app/experts/runes/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.plugins import Plugin
+
+PLUGIN_ID = "runes"
+
+
+def form_steps(locale: str) -> list[dict[str, Any]]:
+    return []
+
+
+def prepare(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def compose(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def write(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "tldr": "Runes plugin response",
+        "sections": [],
+        "actions": [],
+        "disclaimers": [],
+    }
+
+
+def verify(data: dict[str, Any]) -> bool:
+    return True
+
+
+def cta(locale: str) -> list[str]:
+    return []
+
+
+plugin = Plugin(
+    plugin_id=PLUGIN_ID,
+    form_steps=form_steps,
+    prepare=prepare,
+    compose=compose,
+    write=write,
+    verify=verify,
+    cost=0,
+    cta=cta,
+    products_supported=("basic",),
+)

--- a/app/experts/tarot/__init__.py
+++ b/app/experts/tarot/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.plugins import Plugin
+
+PLUGIN_ID = "tarot"
+
+
+def form_steps(locale: str) -> list[dict[str, Any]]:
+    return []
+
+
+def prepare(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def compose(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def write(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "tldr": "Tarot plugin response",
+        "sections": [],
+        "actions": [],
+        "disclaimers": [],
+    }
+
+
+def verify(data: dict[str, Any]) -> bool:
+    return True
+
+
+def cta(locale: str) -> list[str]:
+    return []
+
+
+plugin = Plugin(
+    plugin_id=PLUGIN_ID,
+    form_steps=form_steps,
+    prepare=prepare,
+    compose=compose,
+    write=write,
+    verify=verify,
+    cost=0,
+    cta=cta,
+    products_supported=("basic",),
+)


### PR DESCRIPTION
## Summary
- define plugin interface and registry
- dynamically discover expert modules and expose CLI to list plugins
- stub plugin implementations for existing experts

## Testing
- `ruff check --fix .`
- `black .`
- `ruff check .`
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named "sqlalchemy" [import-not-found])* 
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aacb3c6128832f8279473523d231b4