### PR TITLE
feat: deterministic draw with nonce and tests

### DIFF
--- a/app/core/draw/__init__.py
+++ b/app/core/draw/__init__.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import hashlib
+import random
+from dataclasses import dataclass
+from datetime import date
+from typing import List, Sequence
+
+
+@dataclass(frozen=True)
+class DrawItem:
+    """Result of a draw: item key and orientation."""
+
+    key: str
+    reversed: bool = False
+
+
+def generate_seed(
+    user_id: int | str,
+    expert: str,
+    spread_id: str,
+    draw_date: date,
+    nonce: int = 0,
+) -> int:
+    """Compute deterministic seed for draws.
+
+    The seed formula follows Appendix B:
+    SHA256("user_id|expert|spread_id|YYYYMMDD|nonce").
+    """
+
+    base = f"{user_id}|{expert}|{spread_id}|{draw_date:%Y%m%d}|{nonce}"
+    return int(hashlib.sha256(base.encode("utf-8")).hexdigest(), 16)
+
+
+def draw_unique(
+    items: Sequence[str],
+    count: int,
+    *,
+    user_id: int | str,
+    expert: str,
+    spread_id: str,
+    draw_date: date,
+    nonce: int = 0,
+    allow_reversed: bool = False,
+    p_reversed: float = 0.5,
+) -> List[DrawItem]:
+    """Draw unique items deterministically.
+
+    Args:
+        items: Pool of item keys to draw from.
+        count: Number of items to draw; must not exceed population size.
+        user_id, expert, spread_id, draw_date, nonce: parameters for seed generation.
+        allow_reversed: Whether orientation may be reversed.
+        p_reversed: Probability of an item being reversed when allowed.
+
+    Returns:
+        List of DrawItem preserving draw order.
+    """
+
+    if count > len(items):
+        raise ValueError("Not enough unique items to draw")
+    seed = generate_seed(user_id, expert, spread_id, draw_date, nonce)
+    rng = random.Random(seed)
+    selection = rng.sample(list(items), count)
+    result: List[DrawItem] = []
+    for key in selection:
+        is_reversed = allow_reversed and rng.random() < p_reversed
+        result.append(DrawItem(key=key, reversed=is_reversed))
+    return result
+
+
+__all__ = ["DrawItem", "draw_unique", "generate_seed"]

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -37,8 +37,8 @@ def test_webhook_registration(monkeypatch: pytest.MonkeyPatch) -> None:
     reload(main)
 
     assert main.bot is not None
-    main.bot.set_webhook = AsyncMock()
-    main.dp.feed_update = AsyncMock()
+    main.bot.set_webhook = AsyncMock()  # type: ignore[method-assign]
+    main.dp.feed_update = AsyncMock()  # type: ignore[attr-defined, method-assign]
 
     app = main.create_app()
 
@@ -58,4 +58,4 @@ def test_webhook_registration(monkeypatch: pytest.MonkeyPatch) -> None:
     main.bot.set_webhook.assert_called_once_with(
         "https://example.com", allowed_updates=main.ALLOWED_UPDATES
     )
-    main.dp.feed_update.assert_called_once()
+    main.dp.feed_update.assert_called_once()  # type: ignore[attr-defined]

--- a/app/tests/test_draw.py
+++ b/app/tests/test_draw.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import date
+
+from app.core.draw import draw_unique
+
+
+def test_deterministic_draw_and_nonce() -> None:
+    deck = [f"card{i}" for i in range(10)]
+
+    first = draw_unique(
+        deck,
+        3,
+        user_id=42,
+        expert="tarot",
+        spread_id="tarot_three_ppf",
+        draw_date=date(2024, 1, 1),
+        allow_reversed=True,
+        nonce=0,
+    )
+    second = draw_unique(
+        deck,
+        3,
+        user_id=42,
+        expert="tarot",
+        spread_id="tarot_three_ppf",
+        draw_date=date(2024, 1, 1),
+        allow_reversed=True,
+        nonce=0,
+    )
+    assert first == second
+    assert len({item.key for item in first}) == 3
+
+    third = draw_unique(
+        deck,
+        3,
+        user_id=42,
+        expert="tarot",
+        spread_id="tarot_three_ppf",
+        draw_date=date(2024, 1, 1),
+        allow_reversed=True,
+        nonce=1,
+    )
+    assert third != first
+    assert len({item.key for item in third}) == 3
+    fourth = draw_unique(
+        deck,
+        3,
+        user_id=42,
+        expert="tarot",
+        spread_id="tarot_three_ppf",
+        draw_date=date(2024, 1, 1),
+        allow_reversed=True,
+        nonce=1,
+    )
+    assert third == fourth
+
+    without_rev = draw_unique(
+        deck,
+        3,
+        user_id=42,
+        expert="tarot",
+        spread_id="tarot_three_ppf",
+        draw_date=date(2024, 1, 1),
+        allow_reversed=False,
+        nonce=0,
+    )
+    assert all(not item.reversed for item in without_rev)


### PR DESCRIPTION
## Summary
- implement seed-based deterministic draw with nonce and reversed support
- ensure unique results per spread
- add reproducibility tests for draw logic

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aacf4fac0c832f95713886fb5a4771