### PR TITLE
feat: add image composition module

### DIFF
--- a/app/core/compose/__init__.py
+++ b/app/core/compose/__init__.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from io import BytesIO
+from typing import Sequence
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+@dataclass(frozen=True)
+class CardSpec:
+    """Card image with optional caption and orientation."""
+
+    image: Image.Image
+    caption: str | None = None
+    reversed: bool = False
+
+
+class Layout(str, Enum):
+    """Supported collage layouts."""
+
+    ROW = "row"
+    GRID_3X3 = "3x3"
+    GRAND_TABLEAU = "gt"
+    CROSS = "cross"
+
+
+def _calc_caption_height(cards: Sequence[CardSpec], font: ImageFont.ImageFont) -> int:
+    height = 0
+    for card in cards:
+        if card.caption:
+            bbox = font.getbbox(card.caption)  # type: ignore[no-untyped-call]
+            height = max(height, bbox[3] - bbox[1])
+    return height
+
+
+def compose(
+    cards: Sequence[CardSpec],
+    layout: Layout | str,
+    *,
+    frame: Image.Image | None = None,
+    watermark: Image.Image | None = None,
+    spacing: int = 10,
+    font: ImageFont.ImageFont | None = None,
+    caption_color: str = "black",
+) -> Image.Image:
+    """Compose a collage from given card images.
+
+    Args:
+        cards: Ordered sequence of card specifications.
+        layout: Layout identifier.
+        frame: Optional frame overlay per card.
+        watermark: Optional watermark for bottom-right corner.
+        spacing: Pixel spacing between cards.
+        font: Font to use for captions; defaults to PIL default font.
+        caption_color: Color for captions.
+
+    Returns:
+        Composed PIL image.
+    """
+
+    if not cards:
+        raise ValueError("No cards provided")
+    layout = Layout(layout)
+    font = font or ImageFont.load_default()
+    card_w, card_h = cards[0].image.size
+    cap_h = _calc_caption_height(cards, font)
+    cap_extra = cap_h + 5 if cap_h else 0
+    cell_w = card_w
+    cell_h = card_h + cap_extra
+
+    positions: list[tuple[int, int]]
+    cols: int
+    rows: int
+
+    if layout is Layout.ROW:
+        cols = len(cards)
+        rows = 1
+        positions = [(i * (cell_w + spacing), 0) for i in range(cols)]
+    elif layout is Layout.GRID_3X3:
+        if len(cards) != 9:
+            raise ValueError("3x3 grid requires 9 cards")
+        cols, rows = 3, 3
+        positions = [
+            (c * (cell_w + spacing), r * (cell_h + spacing))
+            for r in range(rows)
+            for c in range(cols)
+        ]
+    elif layout is Layout.GRAND_TABLEAU:
+        if len(cards) != 36:
+            raise ValueError("Grand Tableau requires 36 cards")
+        cols, rows = 9, 4
+        positions = [
+            (c * (cell_w + spacing), r * (cell_h + spacing))
+            for r in range(rows)
+            for c in range(cols)
+        ]
+    elif layout is Layout.CROSS:
+        if len(cards) != 5:
+            raise ValueError("Cross layout requires 5 cards")
+        cols, rows = 3, 3
+        grid_pos = [
+            (1, 1),  # center
+            (1, 0),  # top
+            (2, 1),  # right
+            (1, 2),  # bottom
+            (0, 1),  # left
+        ]
+        positions = [
+            (c * (cell_w + spacing), r * (cell_h + spacing)) for c, r in grid_pos
+        ]
+    else:
+        raise ValueError(f"Unknown layout: {layout}")
+
+    width = cols * cell_w + (cols - 1) * spacing
+    height = rows * cell_h + (rows - 1) * spacing
+    base = Image.new("RGBA", (width, height), (255, 255, 255, 255))
+    draw = ImageDraw.Draw(base)
+
+    frame_img = None
+    if frame:
+        if frame.size != (card_w, card_h):
+            frame_img = frame.resize((card_w, card_h), Image.LANCZOS)
+        else:
+            frame_img = frame
+
+    for card, (x, y) in zip(cards, positions, strict=True):
+        img = card.image
+        if card.reversed:
+            img = img.rotate(180, expand=True)
+        base.paste(img, (x, y))
+        if frame_img:
+            base.paste(frame_img, (x, y), frame_img)
+        if card.caption:
+            bbox = font.getbbox(card.caption)  # type: ignore[no-untyped-call]
+            tw = bbox[2] - bbox[0]
+            tx = x + (card_w - tw) / 2
+            ty = y + card_h + 5
+            draw.text((tx, ty), card.caption, fill=caption_color, font=font)
+
+    if watermark:
+        wm_w, wm_h = watermark.size
+        wx = width - wm_w - 5
+        wy = height - wm_h - 5
+        base.paste(watermark, (wx, wy), watermark)
+
+    return base
+
+
+def save_image(
+    image: Image.Image,
+    *,
+    fmt: str = "WEBP",
+    quality: int = 80,
+    max_bytes: int = 3 * 1024 * 1024,
+    min_quality: int = 20,
+) -> bytes:
+    """Save image ensuring file size is under limit by adjusting quality."""
+
+    fmt = fmt.upper()
+    if fmt not in {"WEBP", "JPEG"}:
+        raise ValueError("fmt must be WEBP or JPEG")
+    buffer = BytesIO()
+    q = quality
+    while q >= min_quality:
+        buffer.seek(0)
+        buffer.truncate(0)
+        if fmt == "JPEG":
+            image.convert("RGB").save(buffer, format=fmt, quality=q, optimize=True)
+        else:
+            image.save(buffer, format=fmt, quality=q)
+        if buffer.tell() <= max_bytes:
+            break
+        q -= 5
+    return buffer.getvalue()
+
+
+__all__ = ["CardSpec", "Layout", "compose", "save_image"]

--- a/app/tests/test_compose.py
+++ b/app/tests/test_compose.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+from app.core.compose import CardSpec, Layout, compose, save_image
+
+
+def _card(top: str, bottom: str) -> Image.Image:
+    img = Image.new("RGB", (100, 150), top)
+    draw = ImageDraw.Draw(img)
+    draw.rectangle((0, 75, 99, 149), fill=bottom)
+    return img
+
+
+def test_row_compose(tmp_path: Path) -> None:
+    frame = Image.new("RGBA", (100, 150), (0, 0, 0, 0))
+    ImageDraw.Draw(frame).rectangle((0, 0, 99, 149), outline="black")
+    watermark = Image.new("RGBA", (20, 10), (255, 0, 0, 255))
+    cards = [
+        CardSpec(_card("red", "blue"), "A", False),
+        CardSpec(_card("red", "green"), "B", True),
+    ]
+    img = compose(cards, Layout.ROW, frame=frame, watermark=watermark)
+    assert img.width == 2 * 100 + 10
+    assert img.height > 150
+    px = img.getpixel((100 + 10 + 5, 5))
+    assert px[:3] == (0, 128, 0) or px[:3] == (0, 255, 0)
+    wm_px = img.getpixel((img.width - 10, img.height - 6))
+    assert wm_px[0] > wm_px[1]
+    data_webp = save_image(img, fmt="WEBP")
+    data_jpeg = save_image(img, fmt="JPEG")
+    assert len(data_webp) <= 3 * 1024 * 1024
+    assert len(data_jpeg) <= 3 * 1024 * 1024
+
+
+def test_other_layouts() -> None:
+    def make_cards(n: int) -> list[CardSpec]:
+        return [
+            CardSpec(Image.new("RGB", (50, 50), (i, i, i)), None, False)
+            for i in range(n)
+        ]
+
+    cross_img = compose(make_cards(5), Layout.CROSS)
+    assert cross_img.size == (3 * 50 + 2 * 10, 3 * 50 + 2 * 10)
+
+    grid_img = compose(make_cards(9), Layout.GRID_3X3)
+    assert grid_img.size == (3 * 50 + 2 * 10, 3 * (50) + 2 * 10)
+
+    gt_img = compose(make_cards(36), Layout.GRAND_TABLEAU)
+    assert gt_img.size == (9 * 50 + 8 * 10, 4 * 50 + 3 * 10)
+
+    import pytest
+
+    with pytest.raises(ValueError):
+        compose(make_cards(4), Layout.CROSS)
+    with pytest.raises(ValueError):
+        compose(make_cards(8), Layout.GRID_3X3)
+    with pytest.raises(ValueError):
+        compose(make_cards(35), Layout.GRAND_TABLEAU)


### PR DESCRIPTION
## Summary
- build card collage layouts (rows, 3x3, grand tableau, cross) with captions, frames, reversed rotation and watermark
- add utility to save images under size limit
- cover composition logic with tests

## Testing
- `python -m ruff check app/core/compose/__init__.py app/tests/test_compose.py`
- `python -m mypy app/core/compose/__init__.py app/tests/test_compose.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aad0c0c1d4832f94a1a67a4c3b614e