### PR TITLE
Implement basic NLP guidance, writer, verifier and localization services

### DIFF
--- a/app/nlp/guide/__init__.py
+++ b/app/nlp/guide/__init__.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Dict
+
+_HINTS: Dict[str, Dict[str, Dict[str, str]]] = {
+    "tarot": {
+        "intro": {
+            "en": "Focus on your question for the cards.",
+            "ru": "Сконцентрируйтесь на своём вопросе для карт.",
+        },
+        "shuffle": {
+            "en": "Shuffle the deck in your mind.",
+            "ru": "Перетасуйте колоду мысленно.",
+        },
+    },
+    "runes": {
+        "intro": {
+            "en": "Calm your mind before drawing runes.",
+            "ru": "Успокойте мысли перед вытягиванием рун.",
+        }
+    },
+}
+
+
+def get_tip(expert: str, step: str, locale: str) -> dict[str, str]:
+    """Return a short tip for a given expert step and locale."""
+
+    expert_hints = _HINTS.get(expert, {})
+    step_hints = expert_hints.get(step, {})
+    tip = step_hints.get(locale) or step_hints.get("en") or ""
+    return {"tip": tip}
+
+
+def register_tip(expert: str, step: str, locale: str, tip: str) -> None:
+    """Register or override a tip."""
+
+    _HINTS.setdefault(expert, {}).setdefault(step, {})[locale] = tip

--- a/app/nlp/localizer/__init__.py
+++ b/app/nlp/localizer/__init__.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+_UI_STRINGS: Dict[str, Dict[str, str]] = {
+    "welcome": {"en": "Welcome", "ru": "Добро пожаловать"},
+    "submit": {"en": "Submit", "ru": "Отправить"},
+}
+
+_EXPERT_NAMES: Dict[str, Dict[str, str]] = {
+    "tarot": {"en": "Tarot reader", "ru": "Таролог"},
+    "runes": {"en": "Runes master", "ru": "Рунолог"},
+}
+
+_DISCLAIMERS: Dict[str, List[str]] = {
+    "en": ["For entertainment purposes only."],
+    "ru": ["Информация предоставлена исключительно в развлекательных целях."],
+}
+
+
+def get_ui_string(key: str, locale: str) -> str:
+    return _UI_STRINGS.get(key, {}).get(locale, key)
+
+
+def get_expert_name(expert: str, locale: str) -> str:
+    return _EXPERT_NAMES.get(expert, {}).get(locale, expert)
+
+
+def get_disclaimers(locale: str) -> List[str]:
+    return _DISCLAIMERS.get(locale, _DISCLAIMERS["en"])

--- a/app/nlp/verifier/__init__.py
+++ b/app/nlp/verifier/__init__.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List
+
+
+@dataclass
+class Diff:
+    path: str
+    expected: str
+    found: str
+
+
+@dataclass
+class VerificationResult:
+    ok: bool
+    diffs: List[Diff]
+
+
+class Verifier:
+    """Simple fact verifier for generated markdown."""
+
+    def verify(self, facts: Dict[str, Any], markdown: str) -> VerificationResult:
+        diffs: List[Diff] = []
+        for key, value in facts.items():
+            value_str = str(value)
+            if value_str not in markdown:
+                diffs.append(Diff(path=key, expected=value_str, found=""))
+        return VerificationResult(ok=not diffs, diffs=diffs)
+
+    def ensure_verified(
+        self,
+        generate: Callable[[Dict[str, Any], str], Dict[str, Any]],
+        facts: Dict[str, Any],
+        locale: str,
+        *,
+        max_attempts: int = 2,
+    ) -> Dict[str, Any]:
+        attempt = 0
+        while attempt < max_attempts:
+            output = generate(facts, locale)
+            markdown = "\n".join(section["body_md"] for section in output["sections"])
+            if self.verify(facts, markdown).ok:
+                return output
+            attempt += 1
+        return output

--- a/app/nlp/writer/__init__.py
+++ b/app/nlp/writer/__init__.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.nlp.localizer import get_disclaimers
+
+
+class Section(BaseModel):
+    title: str
+    body_md: str
+
+
+class WriterOutput(BaseModel):
+    tldr: str = Field(..., max_length=280)
+    sections: list[Section]
+    actions: list[str]
+    disclaimers: list[str]
+
+
+def compose_answer(facts: dict[str, Any], locale: str) -> dict[str, Any]:
+    """Compose a structured answer based on provided facts."""
+
+    tldr = str(facts.get("summary", ""))
+    sections_data = facts.get("sections")
+    if not sections_data:
+        detail = str(facts.get("details", ""))
+        title = "Details" if locale == "en" else "Детали"
+        sections_data = [{"title": title, "body_md": detail}]
+    actions = [str(a) for a in facts.get("actions", [])]
+    disclaimers = [str(d) for d in facts.get("disclaimers", [])]
+    if not disclaimers:
+        disclaimers = get_disclaimers(locale)
+    output = WriterOutput(
+        tldr=tldr,
+        sections=[Section(**sec) for sec in sections_data],
+        actions=actions,
+        disclaimers=disclaimers,
+    )
+    return output.model_dump()

--- a/app/tests/test_nlp_modules.py
+++ b/app/tests/test_nlp_modules.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+from app.nlp.guide import get_tip
+from app.nlp.localizer import (
+    get_disclaimers,
+    get_expert_name,
+    get_ui_string,
+)
+from app.nlp.verifier import Verifier
+from app.nlp.writer import compose_answer
+
+
+def test_guide_tip() -> None:
+    tip = get_tip("tarot", "intro", "en")
+    assert tip == {"tip": "Focus on your question for the cards."}
+
+
+def test_writer_compose_answer() -> None:
+    facts = {
+        "summary": "Short summary",
+        "details": "Detailed text",
+        "actions": ["a1", "a2", "a3"],
+    }
+    result = compose_answer(facts, "en")
+    assert result["tldr"] == "Short summary"
+    assert result["sections"][0]["body_md"] == "Detailed text"
+    assert len(result["actions"]) == 3
+    assert "For entertainment purposes only." in result["disclaimers"][0]
+
+
+def test_verifier_regenerates() -> None:
+    facts = {"number": 42}
+    calls: list[int] = []
+
+    def generate(facts: dict[str, int], locale: str) -> dict[str, Any]:
+        calls.append(len(calls))
+        if len(calls) == 1:
+            return {
+                "tldr": "",
+                "sections": [{"title": "", "body_md": "wrong"}],
+                "actions": [],
+                "disclaimers": [],
+            }
+        return {
+            "tldr": "",
+            "sections": [{"title": "", "body_md": "the answer is 42"}],
+            "actions": [],
+            "disclaimers": [],
+        }
+
+    verifier = Verifier()
+    output = verifier.ensure_verified(generate, facts, "en")
+    assert output["sections"][0]["body_md"] == "the answer is 42"
+    assert len(calls) == 2
+
+
+def test_localizer() -> None:
+    assert get_ui_string("welcome", "ru") == "Добро пожаловать"
+    assert get_expert_name("tarot", "en") == "Tarot reader"
+    assert get_disclaimers("ru")[0].startswith("Информация")


### PR DESCRIPTION
## Summary
- add guidance tips service mapping expert steps to localized hints
- implement writer that builds structured answers and injects localized disclaimers
- add fact verifier with auto-regeneration and localization helpers
- include localizer for UI strings, expert names and disclaimers
- cover NLP services with unit tests

## Testing
- `ruff check app/nlp app/tests/test_nlp_modules.py`
- `mypy app/nlp app/tests/test_nlp_modules.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aad2d47a5c832faad427aa90b19d94