### PR TITLE
feat: implement tarot spreads and asset pipeline

### DIFF
--- a/app/core/compose/__init__.py
+++ b/app/core/compose/__init__.py
@@ -30,7 +30,7 @@ def _calc_caption_height(cards: Sequence[CardSpec], font: ImageFont.ImageFont) -
     height = 0
     for card in cards:
         if card.caption:
-            bbox = font.getbbox(card.caption)  # type: ignore[no-untyped-call]
+            bbox = font.getbbox(card.caption)
             height = max(height, bbox[3] - bbox[1])
     return height
 
@@ -133,7 +133,7 @@ def compose(
         if frame_img:
             base.paste(frame_img, (x, y), frame_img)
         if card.caption:
-            bbox = font.getbbox(card.caption)  # type: ignore[no-untyped-call]
+            bbox = font.getbbox(card.caption)
             tw = bbox[2] - bbox[0]
             tx = x + (card_w - tw) / 2
             ty = y + card_h + 5

--- a/app/experts/tarot/__init__.py
+++ b/app/experts/tarot/__init__.py
@@ -1,39 +1,220 @@
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, List, cast
 
+from PIL import Image
+
+from app.core.assets import ASSET_CACHE
+from app.core.compose import CardSpec, Layout, save_image
+from app.core.compose import compose as compose_cards
+from app.core.draw import draw_unique
 from app.core.plugins import Plugin
+from app.nlp.verifier import Verifier
+from app.nlp.writer import compose_answer
 
 PLUGIN_ID = "tarot"
 
 
+@dataclass(frozen=True)
+class Spread:
+    """Tarot spread configuration."""
+
+    spread_id: str
+    layout: Layout
+    captions: List[str]
+
+
+SPREADS: Dict[str, Spread] = {
+    "tarot_one_daily": Spread("tarot_one_daily", Layout.ROW, ["Daily"]),
+    "tarot_three_ppf": Spread(
+        "tarot_three_ppf", Layout.ROW, ["Past", "Present", "Future"]
+    ),
+    "tarot_three_decision": Spread(
+        "tarot_three_decision", Layout.ROW, ["Option A", "Option B", "Advice"]
+    ),
+    "tarot_five_solution": Spread(
+        "tarot_five_solution",
+        Layout.CROSS,
+        ["Situation", "Challenge", "Advice", "Outcome", "Root"],
+    ),
+    "tarot_celtic_cross_10": Spread(
+        "tarot_celtic_cross_10", Layout.ROW, [str(i) for i in range(1, 11)]
+    ),
+    "tarot_relationship_7": Spread(
+        "tarot_relationship_7",
+        Layout.ROW,
+        [
+            "You",
+            "Partner",
+            "Dynamics",
+            "Advice",
+            "Outcome 1",
+            "Outcome 2",
+            "Overall",
+        ],
+    ),
+    "tarot_career_7": Spread(
+        "tarot_career_7",
+        Layout.ROW,
+        [
+            "Present",
+            "Challenge",
+            "Advice",
+            "Opportunities",
+            "Obstacles",
+            "Outcome",
+            "Overall",
+        ],
+    ),
+    "tarot_yes_no_3": Spread("tarot_yes_no_3", Layout.ROW, ["Yes", "No", "Advice"]),
+}
+
+
 def form_steps(locale: str) -> list[dict[str, Any]]:
-    return []
+    """Input form steps for the tarot expert."""
+
+    return [
+        {"id": "deck_id", "type": "string"},
+        {"id": "spread_id", "type": "string"},
+        {"id": "question", "type": "string"},
+    ]
 
 
 def prepare(data: dict[str, Any]) -> dict[str, Any]:
-    return data
+    """Prepare deterministic draw and card metadata."""
 
+    deck_id = data["deck_id"]
+    spread_id = data["spread_id"]
+    user_id = data.get("user_id", 0)
+    draw_date = data.get("draw_date")
+    if isinstance(draw_date, str):
+        draw_date = date.fromisoformat(draw_date)
+    elif draw_date is None:
+        draw_date = date.today()
+    nonce = int(data.get("nonce", 0))
+    locale = data.get("locale", "en")
 
-def compose(data: dict[str, Any]) -> dict[str, Any]:
-    return data
+    deck_conf = ASSET_CACHE[deck_id]["config"]
+    cards_manifest = deck_conf["cards"]
+    pool = [c["key"] for c in cards_manifest]
+    allow_reversed = bool(deck_conf.get("image", {}).get("allow_reversed", False))
+    spread = SPREADS[spread_id]
 
+    draw = draw_unique(
+        pool,
+        len(spread.captions),
+        user_id=user_id,
+        expert=PLUGIN_ID,
+        spread_id=spread_id,
+        draw_date=draw_date,
+        nonce=nonce,
+        allow_reversed=allow_reversed,
+    )
 
-def write(data: dict[str, Any]) -> dict[str, Any]:
+    by_key = {c["key"]: c for c in cards_manifest}
+    cards: List[Dict[str, Any]] = []
+    for item, caption in zip(draw, spread.captions, strict=True):
+        info = by_key[item.key]
+        cards.append(
+            {
+                "key": item.key,
+                "file": info["file"],
+                "display": info["display"],
+                "caption": caption,
+                "reversed": item.reversed,
+            }
+        )
+
+    assets_root = Path(data.get("assets_root", "assets"))
+
     return {
-        "tldr": "Tarot plugin response",
-        "sections": [],
-        "actions": [],
-        "disclaimers": [],
+        "deck_id": deck_id,
+        "spread_id": spread_id,
+        "spread": spread,
+        "cards": cards,
+        "locale": locale,
+        "assets_root": str(assets_root),
     }
 
 
+def compose(data: dict[str, Any]) -> dict[str, Any]:
+    """Compose card collage with captions and optional frame."""
+
+    deck_id = data["deck_id"]
+    spread: Spread = data["spread"]
+    locale = data.get("locale", "en")
+    assets_root = Path(data.get("assets_root", "assets"))
+    deck_path = assets_root / "tarot" / deck_id
+
+    frame_img = None
+    frame_path = deck_path / "frame.png"
+    if frame_path.exists():
+        frame_img = Image.open(frame_path)
+
+    card_specs: List[CardSpec] = []
+    names: List[str] = []
+    for card in data["cards"]:
+        img_path = deck_path / "cards" / card["file"]
+        image = Image.open(img_path)
+        name = card["display"].get(locale) or next(iter(card["display"].values()))
+        names.append(name)
+        caption = f"{card['caption']}: {name}"
+        card_specs.append(
+            CardSpec(image=image, caption=caption, reversed=card["reversed"])
+        )
+
+    collage = compose_cards(card_specs, spread.layout, frame=frame_img)
+    image_bytes = save_image(collage, fmt="WEBP")
+
+    facts = {f"card_{i + 1}": name for i, name in enumerate(names)}
+
+    return {
+        **data,
+        "image": image_bytes,
+        "image_format": "WEBP",
+        "facts": facts,
+    }
+
+
+def write(data: dict[str, Any]) -> dict[str, Any]:
+    """Generate textual reading and ensure factual accuracy."""
+
+    locale = data.get("locale", "en")
+    names = [name for name in data["facts"].values()]
+    summary = ", ".join(names)
+    details = "\n".join(f"{i + 1}. {name}" for i, name in enumerate(names))
+    actions = [
+        "Reflect on how the cards relate to your question.",
+        "Trust your intuition as you interpret the spread.",
+        "Record your insights for future reference.",
+    ]
+
+    facts = {
+        **data["facts"],
+        "summary": summary,
+        "details": details,
+        "actions": actions,
+    }
+    verifier = Verifier()
+    output = verifier.ensure_verified(compose_answer, facts, locale)
+    result = cast(dict[str, Any], output)
+    result["facts"] = data["facts"]
+    return result
+
+
 def verify(data: dict[str, Any]) -> bool:
-    return True
+    facts = data.get("facts", {})
+    markdown = "\n".join(section["body_md"] for section in data.get("sections", []))
+    verifier = Verifier()
+    result = verifier.verify(facts, markdown)
+    return bool(getattr(result, "ok", False))
 
 
 def cta(locale: str) -> list[str]:
-    return []
+    return ["Draw another card", "Try another spread", "Share"]
 
 
 plugin = Plugin(

--- a/app/tests/test_tarot_plugin.py
+++ b/app/tests/test_tarot_plugin.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+from PIL import Image
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.sqlite import JSON as SQLITE_JSON
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.core.assets import ASSET_CACHE, load_assets
+from app.db import models
+from app.db.base import Base
+from app.experts import tarot
+
+
+def _create_image(path: Path, size: tuple[int, int] = (300, 500)) -> None:
+    Image.new("RGB", size, "white").save(path)
+
+
+def _setup_session() -> Session:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    models.JSONB = SQLITE_JSON
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, future=True)()
+
+
+def test_tarot_pipeline(tmp_path: Path) -> None:
+    ASSET_CACHE.clear()
+    deck_dir = tmp_path / "tarot" / "sample"
+    cards_dir = deck_dir / "cards"
+    cards_dir.mkdir(parents=True)
+    _create_image(deck_dir / "back.png")
+    Image.new("RGBA", (300, 500), (0, 0, 0, 0)).save(deck_dir / "frame.png")
+    for i in range(3):
+        _create_image(cards_dir / f"{i}.png")
+    manifest = {
+        "deck_id": "sample",
+        "name": {"en": "Sample", "ru": "Пример"},
+        "type": "tarot",
+        "image": {
+            "aspect_ratio": "3:5",
+            "allow_reversed": True,
+            "default_back": "back.png",
+        },
+        "cards": [
+            {
+                "key": f"c{i}",
+                "display": {"en": f"Card {i}"},
+                "file": f"{i}.png",
+                "arcana": "major",
+                "upright": [],
+                "reversed": [],
+            }
+            for i in range(3)
+        ],
+    }
+    (deck_dir / "deck.json").write_text(json.dumps(manifest), encoding="utf-8")
+    session = _setup_session()
+    load_assets(tmp_path, session)
+
+    params = {
+        "deck_id": "sample",
+        "spread_id": "tarot_three_ppf",
+        "user_id": 42,
+        "draw_date": date(2024, 1, 1),
+        "nonce": 0,
+        "locale": "en",
+        "assets_root": str(tmp_path),
+    }
+    prep1 = tarot.prepare(params)
+    prep2 = tarot.prepare(params)
+    assert prep1["cards"] == prep2["cards"]
+
+    comp = tarot.compose(prep1)
+    assert isinstance(comp["image"], bytes) and len(comp["image"]) > 0
+
+    text = tarot.write(comp)
+    assert text["tldr"]
+    assert len(text["actions"]) == 3
+    assert text["disclaimers"]
+    assert tarot.verify(text)


### PR DESCRIPTION
## Summary
- implement full tarot spreads with deterministic draws and reversals
- compose tarot card collages with captions and frames
- generate and verify structured reading output

## Testing
- `ruff check app/experts/tarot/__init__.py app/tests/test_tarot_plugin.py app/core/compose/__init__.py app/core/assets/loader.py`
- `mypy --follow-imports=skip app/experts/tarot/__init__.py app/tests/test_tarot_plugin.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aad4e56b74832fa7e859dd41475eb1