### PR TITLE
Add runes expert with spreads and tests

### DIFF
--- a/app/experts/runes/__init__.py
+++ b/app/experts/runes/__init__.py
@@ -1,39 +1,213 @@
 from __future__ import annotations
 
-from typing import Any
+import importlib
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, List
 
+from PIL import Image
+
+from app.core.assets import ASSET_CACHE
+from app.core.draw import draw_unique
 from app.core.plugins import Plugin
+from app.nlp.verifier import Verifier
+from app.nlp.writer import compose_answer
+
+compose_mod = importlib.import_module("app.core.compose")
+CardSpec: Any = compose_mod.CardSpec
+Layout: Any = compose_mod.Layout
+compose_cards = compose_mod.compose
+save_image = compose_mod.save_image
 
 PLUGIN_ID = "runes"
 
 
+@dataclass(frozen=True)
+class Spread:
+    """Runes spread configuration."""
+
+    spread_id: str
+    layout: Layout
+    captions: List[str]
+
+
+SPREADS: Dict[str, Spread] = {
+    "runes_one": Spread("runes_one", Layout.ROW, ["Rune"]),
+    "runes_three_ppf": Spread(
+        "runes_three_ppf", Layout.ROW, ["Past", "Present", "Future"]
+    ),
+    "runes_five_cross": Spread(
+        "runes_five_cross",
+        Layout.CROSS,
+        ["Situation", "Challenge", "Advice", "Outcome", "Root"],
+    ),
+}
+
+
 def form_steps(locale: str) -> list[dict[str, Any]]:
-    return []
+    """Input form steps for the runes expert."""
+
+    return [
+        {"id": "set_id", "type": "string"},
+        {"id": "spread_id", "type": "string"},
+        {"id": "question", "type": "string"},
+    ]
 
 
 def prepare(data: dict[str, Any]) -> dict[str, Any]:
-    return data
+    """Prepare deterministic rune draw and metadata."""
 
+    set_id = data["set_id"]
+    spread_id = data["spread_id"]
+    user_id = data.get("user_id", 0)
+    draw_date = data.get("draw_date")
+    if isinstance(draw_date, str):
+        draw_date = date.fromisoformat(draw_date)
+    elif draw_date is None:
+        draw_date = date.today()
+    nonce = int(data.get("nonce", 0))
+    locale = data.get("locale", "en")
 
-def compose(data: dict[str, Any]) -> dict[str, Any]:
-    return data
+    set_conf = ASSET_CACHE[set_id]["config"]
+    runes_manifest = set_conf["runes"]
+    pool = [r["key"] for r in runes_manifest]
+    allow_reversed = bool(set_conf.get("image", {}).get("allow_reversed", False))
+    spread = SPREADS[spread_id]
 
+    draw = draw_unique(
+        pool,
+        len(spread.captions),
+        user_id=user_id,
+        expert=PLUGIN_ID,
+        spread_id=spread_id,
+        draw_date=draw_date,
+        nonce=nonce,
+        allow_reversed=allow_reversed,
+        p_reversed=0.33,
+    )
 
-def write(data: dict[str, Any]) -> dict[str, Any]:
+    by_key = {r["key"]: r for r in runes_manifest}
+    runes: List[Dict[str, Any]] = []
+    for item, caption in zip(draw, spread.captions, strict=True):
+        info = by_key[item.key]
+        can_reverse = bool(info.get("can_reverse", True))
+        runes.append(
+            {
+                "key": item.key,
+                "file": info["file"],
+                "display": info["display"],
+                "caption": caption,
+                "reversed": item.reversed if can_reverse else False,
+            }
+        )
+
+    assets_root = Path(data.get("assets_root", "assets"))
+
     return {
-        "tldr": "Runes plugin response",
-        "sections": [],
-        "actions": [],
-        "disclaimers": [],
+        "set_id": set_id,
+        "spread_id": spread_id,
+        "spread": spread,
+        "runes": runes,
+        "locale": locale,
+        "assets_root": str(assets_root),
     }
 
 
+def compose(data: dict[str, Any]) -> dict[str, Any]:
+    """Compose rune collage with captions."""
+
+    set_id = data["set_id"]
+    spread: Spread = data["spread"]
+    locale = data.get("locale", "en")
+    assets_root = Path(data.get("assets_root", "assets"))
+    set_path = assets_root / "runes" / set_id
+
+    frame_img = None
+    frame_path = set_path / "frame.png"
+    if frame_path.exists():
+        frame_img = Image.open(frame_path)
+
+    rune_specs: List[CardSpec] = []
+    names: List[str] = []
+    orientations: List[str] = []
+    for rune in data["runes"]:
+        img_path = set_path / "runes" / rune["file"]
+        image = Image.open(img_path)
+        name = rune["display"].get(locale) or next(iter(rune["display"].values()))
+        names.append(name)
+        orientation = "reversed" if rune["reversed"] else "upright"
+        orientations.append(orientation)
+        caption = f"{rune['caption']}: {name}"
+        rune_specs.append(
+            CardSpec(image=image, caption=caption, reversed=rune["reversed"])
+        )
+
+    collage = compose_cards(rune_specs, spread.layout, frame=frame_img)
+    image_bytes = save_image(collage, fmt="WEBP")
+
+    facts: Dict[str, Any] = {}
+    for i, (name, orientation) in enumerate(
+        zip(names, orientations, strict=True), start=1
+    ):
+        facts[f"rune_{i}"] = name
+        facts[f"rune_{i}_orientation"] = orientation
+
+    return {
+        **data,
+        "image": image_bytes,
+        "image_format": "WEBP",
+        "facts": facts,
+    }
+
+
+def write(data: dict[str, Any]) -> dict[str, Any]:
+    """Generate textual reading for runes and verify facts."""
+
+    locale = data.get("locale", "en")
+    facts = data["facts"]
+    count = len([k for k in facts if k.startswith("rune_") and "_orientation" not in k])
+    names = [facts[f"rune_{i}"] for i in range(1, count + 1)]
+    summary = ", ".join(names)
+
+    sections: List[Dict[str, str]] = []
+    for i in range(1, count + 1):
+        name = facts[f"rune_{i}"]
+        orientation = facts[f"rune_{i}_orientation"]
+        body = f"The {name} rune appears {orientation}."
+        sections.append({"title": name, "body_md": body})
+
+    actions = [
+        "Reflect on how the runes relate to your question.",
+        "Trust your intuition as you interpret their meanings.",
+        "Record your insights for future reference.",
+    ]
+    disclaimers = ["For entertainment purposes only."]
+
+    verify_facts = {
+        **facts,
+        "summary": summary,
+        "sections": sections,
+        "actions": actions,
+        "disclaimers": disclaimers,
+    }
+    verifier = Verifier()
+    output = verifier.ensure_verified(compose_answer, verify_facts, locale)
+    result: dict[str, Any] = output
+    result["facts"] = facts
+    return result
+
+
 def verify(data: dict[str, Any]) -> bool:
-    return True
+    facts = data.get("facts", {})
+    markdown = "\n".join(section["body_md"] for section in data.get("sections", []))
+    verifier = Verifier()
+    result = verifier.verify(facts, markdown)
+    return bool(getattr(result, "ok", False))
 
 
 def cta(locale: str) -> list[str]:
-    return []
+    return ["Draw another rune", "Try another spread", "Share"]
 
 
 plugin = Plugin(

--- a/app/tests/test_runes_plugin.py
+++ b/app/tests/test_runes_plugin.py
@@ -1,0 +1,85 @@
+import json
+from datetime import date
+from pathlib import Path
+
+from PIL import Image
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.sqlite import JSON as SQLITE_JSON
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.core.assets import ASSET_CACHE, load_assets
+from app.db import models
+from app.db.base import Base
+from app.experts import runes
+
+
+def _create_image(path: Path, size: tuple[int, int] = (300, 300)) -> None:
+    Image.new("RGB", size, "white").save(path)
+
+
+def _setup_session() -> Session:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    models.JSONB = SQLITE_JSON  # type: ignore[attr-defined]
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, future=True)()
+
+
+def test_runes_pipeline(tmp_path: Path) -> None:
+    ASSET_CACHE.clear()
+    set_dir = tmp_path / "runes" / "sample"
+    runes_dir = set_dir / "runes"
+    runes_dir.mkdir(parents=True)
+    _create_image(set_dir / "back.png")
+    for i in range(5):
+        _create_image(runes_dir / f"{i}.png")
+    manifest = {
+        "set_id": "sample",
+        "name": {"en": "Sample", "ru": "Пример"},
+        "type": "runes",
+        "image": {
+            "aspect_ratio": "1:1",
+            "allow_reversed": True,
+            "default_back": "back.png",
+        },
+        "runes": [
+            {
+                "key": f"r{i}",
+                "display": {"en": f"Rune {i}"},
+                "file": f"{i}.png",
+                "can_reverse": i % 2 == 0,
+            }
+            for i in range(5)
+        ],
+    }
+    (set_dir / "set.json").write_text(json.dumps(manifest), encoding="utf-8")
+    session = _setup_session()
+    load_assets(tmp_path, session)
+
+    params = {
+        "set_id": "sample",
+        "spread_id": "runes_five_cross",
+        "user_id": 42,
+        "draw_date": date(2024, 1, 1),
+        "nonce": 0,
+        "locale": "en",
+        "assets_root": str(tmp_path),
+    }
+    prep1 = runes.prepare(params)
+    prep2 = runes.prepare(params)
+    assert prep1["runes"] == prep2["runes"]
+
+    conf = ASSET_CACHE["sample"]["config"]
+    by_key = {r["key"]: r for r in conf["runes"]}
+    for r in prep1["runes"]:
+        if not by_key[r["key"]]["can_reverse"]:
+            assert not r["reversed"]
+
+    comp = runes.compose(prep1)
+    assert isinstance(comp["image"], bytes) and len(comp["image"]) > 0
+
+    text = runes.write(comp)
+    assert text["tldr"]
+    assert text["sections"]
+    assert text["actions"]
+    assert text["disclaimers"]
+    assert runes.verify(text)


### PR DESCRIPTION
## Summary
- implement runes expert with one, three, and five-card spreads
- handle rune reversal with probability and metadata
- cover runes pipeline with a unit test

## Testing
- `ruff check app/experts/runes/__init__.py app/tests/test_runes_plugin.py`
- `black app/experts/runes/__init__.py app/tests/test_runes_plugin.py`
- `mypy app/experts/runes/__init__.py app/tests/test_runes_plugin.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aad8662c00832faa61b105fb0020b1