### PR TITLE
feat: add copywriter and assistant pipeline

### DIFF
--- a/app/experts/assistant/__init__.py
+++ b/app/experts/assistant/__init__.py
@@ -1,39 +1,142 @@
 from __future__ import annotations
 
-from typing import Any
+from datetime import date
+from pathlib import Path
+from typing import Any, cast
 
+from PIL import Image, ImageDraw, ImageFont
+
+from app.core.compose import save_image
+from app.core.draw import draw_unique
 from app.core.plugins import Plugin
+from app.nlp.verifier import Verifier
+from app.nlp.writer import compose_answer
 
 PLUGIN_ID = "assistant"
 
 
 def form_steps(locale: str) -> list[dict[str, Any]]:
-    return []
+    """Collect request theme and optional brief."""
+
+    return [
+        {"id": "theme", "type": "string"},
+        {"id": "brief", "type": "string", "optional": True},
+    ]
 
 
 def prepare(data: dict[str, Any]) -> dict[str, Any]:
-    return data
+    """Select optional poster asset deterministically."""
 
-
-def compose(data: dict[str, Any]) -> dict[str, Any]:
-    return data
-
-
-def write(data: dict[str, Any]) -> dict[str, Any]:
+    theme = str(data["theme"])
+    brief = str(data.get("brief", ""))
+    assets_root = Path(data.get("assets_root", "assets"))
+    poster_asset = data.get("poster_asset")
+    poster_path: Path | None = None
+    if poster_asset:
+        poster_path = assets_root / poster_asset
+    else:
+        poster_dir = assets_root / "posters"
+        if poster_dir.exists():
+            pool = [
+                p.name
+                for p in poster_dir.iterdir()
+                if p.is_file()
+                and p.suffix.lower() in {".png", ".jpg", ".jpeg", ".webp"}
+            ]
+            if pool:
+                user_id = data.get("user_id", 0)
+                draw_date = data.get("draw_date")
+                if isinstance(draw_date, str):
+                    draw_date = date.fromisoformat(draw_date)
+                elif draw_date is None:
+                    draw_date = date.today()
+                nonce = int(data.get("nonce", 0))
+                pick = draw_unique(
+                    pool,
+                    1,
+                    user_id=user_id,
+                    expert=PLUGIN_ID,
+                    spread_id="poster",
+                    draw_date=draw_date,
+                    nonce=nonce,
+                )[0]
+                poster_path = poster_dir / pick.key
     return {
-        "tldr": "Assistant plugin response",
-        "sections": [],
-        "actions": [],
-        "disclaimers": [],
+        "theme": theme,
+        "brief": brief,
+        "poster_asset": str(poster_path) if poster_path else None,
+        "assets_root": str(assets_root),
+        "locale": data.get("locale", "en"),
     }
 
 
+def compose(data: dict[str, Any]) -> dict[str, Any]:
+    """Build optional poster image and collect facts."""
+
+    poster_path = data.get("poster_asset")
+    theme = data["theme"]
+    brief = data.get("brief", "")
+    image: Image.Image
+    if poster_path and Path(poster_path).exists():
+        image = Image.open(poster_path)
+    else:
+        image = Image.new("RGB", (1200, 630), color="white")
+        draw = ImageDraw.Draw(image)
+        font = ImageFont.load_default()
+        bbox = font.getbbox(theme)
+        x = (image.width - (bbox[2] - bbox[0])) // 2
+        y = (image.height - (bbox[3] - bbox[1])) // 2
+        draw.text((x, y), theme, fill="black", font=font)
+    image_bytes = save_image(image, fmt="WEBP")
+    facts = {"theme": theme}
+    if brief:
+        facts["brief"] = brief
+    return {**data, "image": image_bytes, "image_format": "WEBP", "facts": facts}
+
+
+def write(data: dict[str, Any]) -> dict[str, Any]:
+    """Generate TL;DR, sections and actions."""
+
+    locale = data.get("locale", "en")
+    theme = data["facts"]["theme"]
+    brief = data["facts"].get("brief", "")
+    summary = f"{theme}: {brief}" if brief else theme
+    sections = [{"title": "Request" if locale == "en" else "Запрос", "body_md": theme}]
+    if brief:
+        sections.append(
+            {"title": "Details" if locale == "en" else "Детали", "body_md": brief}
+        )
+    actions = [
+        "Check the response.",
+        "Ask follow-up questions.",
+        "Apply the suggestions.",
+    ]
+    facts = {
+        **data["facts"],
+        "summary": summary,
+        "sections": sections,
+        "actions": actions,
+    }
+    verifier = Verifier()
+    output = cast(
+        dict[str, Any], verifier.ensure_verified(compose_answer, facts, locale)
+    )
+    output["facts"] = data["facts"]
+    return output
+
+
 def verify(data: dict[str, Any]) -> bool:
-    return True
+    """Verify generated markdown against facts."""
+
+    facts = data.get("facts", {})
+    markdown = "\n".join(section["body_md"] for section in data.get("sections", []))
+    verifier = Verifier()
+    result = verifier.verify(facts, markdown)
+    return bool(getattr(result, "ok", False))
 
 
 def cta(locale: str) -> list[str]:
-    return []
+    return ["Refine", "New request", "Share"]
 
 
 plugin = Plugin(

--- a/app/experts/copywriter/__init__.py
+++ b/app/experts/copywriter/__init__.py
@@ -1,39 +1,138 @@
 from __future__ import annotations
 
-from typing import Any
+from datetime import date
+from pathlib import Path
+from typing import Any, cast
 
+from PIL import Image, ImageDraw, ImageFont
+
+from app.core.compose import save_image
+from app.core.draw import draw_unique
 from app.core.plugins import Plugin
+from app.nlp.verifier import Verifier
+from app.nlp.writer import compose_answer
 
 PLUGIN_ID = "copywriter"
 
 
 def form_steps(locale: str) -> list[dict[str, Any]]:
-    return []
+    """Collect theme and optional brief from user."""
+
+    return [
+        {"id": "theme", "type": "string"},
+        {"id": "brief", "type": "string", "optional": True},
+    ]
 
 
 def prepare(data: dict[str, Any]) -> dict[str, Any]:
-    return data
+    """Select optional banner asset deterministically."""
 
-
-def compose(data: dict[str, Any]) -> dict[str, Any]:
-    return data
-
-
-def write(data: dict[str, Any]) -> dict[str, Any]:
+    theme = str(data["theme"])
+    brief = str(data.get("brief", ""))
+    assets_root = Path(data.get("assets_root", "assets"))
+    banner_asset = data.get("banner_asset")
+    banner_path: Path | None = None
+    if banner_asset:
+        banner_path = assets_root / banner_asset
+    else:
+        banner_dir = assets_root / "banners"
+        if banner_dir.exists():
+            pool = [
+                p.name
+                for p in banner_dir.iterdir()
+                if p.is_file()
+                and p.suffix.lower() in {".png", ".jpg", ".jpeg", ".webp"}
+            ]
+            if pool:
+                user_id = data.get("user_id", 0)
+                draw_date = data.get("draw_date")
+                if isinstance(draw_date, str):
+                    draw_date = date.fromisoformat(draw_date)
+                elif draw_date is None:
+                    draw_date = date.today()
+                nonce = int(data.get("nonce", 0))
+                pick = draw_unique(
+                    pool,
+                    1,
+                    user_id=user_id,
+                    expert=PLUGIN_ID,
+                    spread_id="banner",
+                    draw_date=draw_date,
+                    nonce=nonce,
+                )[0]
+                banner_path = banner_dir / pick.key
     return {
-        "tldr": "Copywriter plugin response",
-        "sections": [],
-        "actions": [],
-        "disclaimers": [],
+        "theme": theme,
+        "brief": brief,
+        "banner_asset": str(banner_path) if banner_path else None,
+        "assets_root": str(assets_root),
+        "locale": data.get("locale", "en"),
     }
 
 
+def compose(data: dict[str, Any]) -> dict[str, Any]:
+    """Build optional banner image and collect facts."""
+
+    banner_path = data.get("banner_asset")
+    theme = data["theme"]
+    brief = data.get("brief", "")
+    image: Image.Image
+    if banner_path and Path(banner_path).exists():
+        image = Image.open(banner_path)
+    else:
+        image = Image.new("RGB", (1200, 630), color="white")
+        draw = ImageDraw.Draw(image)
+        font = ImageFont.load_default()
+        bbox = font.getbbox(theme)
+        x = (image.width - (bbox[2] - bbox[0])) // 2
+        y = (image.height - (bbox[3] - bbox[1])) // 2
+        draw.text((x, y), theme, fill="black", font=font)
+    image_bytes = save_image(image, fmt="WEBP")
+    facts = {"theme": theme}
+    if brief:
+        facts["brief"] = brief
+    return {**data, "image": image_bytes, "image_format": "WEBP", "facts": facts}
+
+
+def write(data: dict[str, Any]) -> dict[str, Any]:
+    """Generate TL;DR, sections and actions using writer pipeline."""
+
+    locale = data.get("locale", "en")
+    theme = data["facts"]["theme"]
+    brief = data["facts"].get("brief", "")
+    summary = f"{theme}: {brief}" if brief else theme
+    sections = [{"title": "Theme" if locale == "en" else "Тема", "body_md": theme}]
+    if brief:
+        sections.append(
+            {"title": "Brief" if locale == "en" else "Бриф", "body_md": brief}
+        )
+    actions = ["Outline main points.", "Draft the text.", "Edit and publish."]
+    facts = {
+        **data["facts"],
+        "summary": summary,
+        "sections": sections,
+        "actions": actions,
+    }
+    verifier = Verifier()
+    output = cast(
+        dict[str, Any], verifier.ensure_verified(compose_answer, facts, locale)
+    )
+    output["facts"] = data["facts"]
+    return output
+
+
 def verify(data: dict[str, Any]) -> bool:
-    return True
+    """Verify generated markdown against initial facts."""
+
+    facts = data.get("facts", {})
+    markdown = "\n".join(section["body_md"] for section in data.get("sections", []))
+    verifier = Verifier()
+    result = verifier.verify(facts, markdown)
+    return bool(getattr(result, "ok", False))
 
 
 def cta(locale: str) -> list[str]:
-    return []
+    return ["Clarify", "Try another topic", "Share"]
 
 
 plugin = Plugin(


### PR DESCRIPTION
## Summary
- implement copywriter plugin with theme/brief input, banner support, and writer/verifier flow
- add assistant plugin mirroring pipeline with optional poster assets

## Testing
- `python -m ruff check app/experts/copywriter/__init__.py app/experts/assistant/__init__.py`
- `python -m mypy --follow-imports=skip app/experts/copywriter/__init__.py app/experts/assistant/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aae005fdc0832fb7bdafefd1cb4605