### PR TITLE
Implement payments storefront and limit tracking

### DIFF
--- a/app/core/limits/__init__.py
+++ b/app/core/limits/__init__.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from contextlib import contextmanager
+from datetime import datetime
+from typing import Iterator
+
+from sqlalchemy.orm import Session
+
+from app.db.models import Entitlement, Usage
+
+ANTI_FLOOD_SECONDS = 3
+
+
+class QuotaError(Exception):
+    """Raised when user has insufficient quota."""
+
+
+class DailyCapError(Exception):
+    """Raised when fair daily cap is exceeded."""
+
+
+class FloodError(Exception):
+    """Raised on too frequent requests."""
+
+
+class ParallelismError(Exception):
+    """Raised when user runs too many parallel operations."""
+
+
+_inflight: dict[int, int] = defaultdict(int)
+
+
+@contextmanager
+def _track(user_id: int) -> Iterator[None]:
+    count = _inflight[user_id]
+    if count >= 2:
+        raise ParallelismError("too many parallel operations")
+    _inflight[user_id] = count + 1
+    try:
+        yield
+    finally:
+        _inflight[user_id] -= 1
+
+
+def consume(session: Session, user_id: int, expert: str, cost: int = 1) -> None:
+    """Consume quota for the given user and record usage."""
+
+    with _track(user_id):
+        now = datetime.utcnow()
+        entitlement = (
+            session.query(Entitlement)
+            .filter(Entitlement.user_id == user_id, Entitlement.status == "active")
+            .order_by(Entitlement.created_at.desc())
+            .first()
+        )
+        if entitlement is None or (
+            entitlement.expires_at and entitlement.expires_at < now
+        ):
+            raise QuotaError("no active entitlement")
+        if entitlement.quota_left > 0 and entitlement.quota_left < cost:
+            raise QuotaError("not enough quota")
+        last_usage = (
+            session.query(Usage)
+            .filter(Usage.user_id == user_id)
+            .order_by(Usage.created_at.desc())
+            .first()
+        )
+        if (
+            last_usage
+            and (now - last_usage.created_at).total_seconds() < ANTI_FLOOD_SECONDS
+        ):
+            raise FloodError("too frequent requests")
+        start_day = datetime(now.year, now.month, now.day)
+        today_count = (
+            session.query(Usage)
+            .filter(Usage.user_id == user_id, Usage.created_at >= start_day)
+            .count()
+        )
+        if entitlement.fair_daily_cap and today_count >= entitlement.fair_daily_cap:
+            raise DailyCapError("daily cap reached")
+        if entitlement.quota_left > 0:
+            entitlement.quota_left -= cost
+        session.add(
+            Usage(
+                id=int(now.timestamp() * 1000),
+                user_id=user_id,
+                expert=expert,
+                cost=cost,
+            )
+        )
+        session.commit()

--- a/app/core/payments/__init__.py
+++ b/app/core/payments/__init__.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Dict
+
+from aiogram import Bot, types
+from sqlalchemy.orm import Session
+
+from app.db.models import Entitlement, Order
+
+
+@dataclass(frozen=True)
+class Product:
+    """Representation of a sellable product."""
+
+    product_id: str
+    title: str
+    amount_xtr: int
+    quota: int
+    duration_days: int | None
+    fair_daily_cap: int
+
+
+PRODUCT_CATALOG: Dict[str, Product] = {
+    "pack_3": Product(
+        product_id="pack_3",
+        title="3 Requests",
+        amount_xtr=300,
+        quota=3,
+        duration_days=None,
+        fair_daily_cap=3,
+    ),
+    "pack_10": Product(
+        product_id="pack_10",
+        title="10 Requests",
+        amount_xtr=900,
+        quota=10,
+        duration_days=None,
+        fair_daily_cap=5,
+    ),
+    "unlimited_30d": Product(
+        product_id="unlimited_30d",
+        title="Unlimited 30d",
+        amount_xtr=3000,
+        quota=0,
+        duration_days=30,
+        fair_daily_cap=20,
+    ),
+    "sub_30d": Product(
+        product_id="sub_30d",
+        title="Subscription 30d",
+        amount_xtr=1500,
+        quota=30,
+        duration_days=30,
+        fair_daily_cap=5,
+    ),
+}
+
+
+class PaymentError(Exception):
+    """Raised when payment processing fails."""
+
+
+def create_order(session: Session, user_id: int, product_id: str) -> Order:
+    """Create a new order for the given product."""
+
+    product = PRODUCT_CATALOG.get(product_id)
+    if product is None:
+        raise PaymentError("unknown product")
+    order = Order(
+        id=int(datetime.utcnow().timestamp() * 1000),
+        user_id=user_id,
+        product=product_id,
+        amount_xtr=product.amount_xtr,
+        currency="XTR",
+        status="pending",
+    )
+    session.add(order)
+    session.commit()
+    return order
+
+
+async def send_product_invoice(bot: Bot, chat_id: int, order: Order) -> types.Message:
+    """Send a Telegram invoice for the specified order."""
+
+    product = PRODUCT_CATALOG[order.product]
+    price = types.LabeledPrice(label=product.title, amount=product.amount_xtr)
+    return await bot.send_invoice(
+        chat_id=chat_id,
+        title=product.title,
+        description=product.title,
+        payload=str(order.id),
+        currency="XTR",
+        prices=[price],
+    )
+
+
+async def handle_pre_checkout(query: types.PreCheckoutQuery, session: Session) -> None:
+    """Process pre-checkout queries from Telegram."""
+
+    order = session.get(Order, int(query.invoice_payload))
+    if order is None:
+        await query.answer(ok=False, error_message="order not found")
+        return
+    order.status = "pre_checkout"
+    session.commit()
+    await query.answer(ok=True)
+
+
+async def handle_successful_payment(message: types.Message, session: Session) -> None:
+    """Finalize payment and grant entitlements."""
+
+    sp = message.successful_payment
+    if sp is None:
+        return
+    order = session.get(Order, int(sp.invoice_payload))
+    if order is None:
+        return
+    order.status = "paid"
+    order.external_id = sp.telegram_payment_charge_id
+    product = PRODUCT_CATALOG[order.product]
+    expires_at = (
+        datetime.utcnow() + timedelta(days=product.duration_days)
+        if product.duration_days
+        else None
+    )
+    entitlement = Entitlement(
+        id=int(datetime.utcnow().timestamp() * 1000),
+        user_id=order.user_id,
+        product=order.product,
+        status="active",
+        expires_at=expires_at,
+        quota_total=product.quota,
+        quota_left=product.quota,
+        fair_daily_cap=product.fair_daily_cap,
+    )
+    session.add(entitlement)
+    session.commit()

--- a/app/tests/test_limits.py
+++ b/app/tests/test_limits.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.sqlite import JSON as SQLITE_JSON
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.core.limits import (
+    ANTI_FLOOD_SECONDS,
+    DailyCapError,
+    FloodError,
+    ParallelismError,
+    _track,
+    consume,
+)
+from app.db import models
+from app.db.base import Base
+from app.db.models import Entitlement, Usage, User
+
+
+def _setup_session() -> Session:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    models.JSONB = SQLITE_JSON  # type: ignore[attr-defined]
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, future=True)()
+
+
+def _prepare_entitlement(session: Session) -> int:
+    user = User(id=1, tg_id=1)
+    session.add(user)
+    session.commit()
+    ent = Entitlement(
+        id=1,
+        user_id=user.id,
+        product="pack_3",
+        status="active",
+        quota_total=2,
+        quota_left=2,
+        fair_daily_cap=1,
+    )
+    session.add(ent)
+    session.commit()
+    return user.id
+
+
+def test_consume_records_usage_and_deducts_quota() -> None:
+    session = _setup_session()
+    user_id = _prepare_entitlement(session)
+    consume(session, user_id=user_id, expert="tarot")
+    ent = session.get(Entitlement, 1)
+    assert ent is not None
+    assert ent.quota_left == 1
+    usage = session.query(Usage).one()
+    assert usage.cost == 1
+
+
+def test_consume_anti_flood_and_daily_cap() -> None:
+    session = _setup_session()
+    user_id = _prepare_entitlement(session)
+    consume(session, user_id=user_id, expert="tarot")
+    with pytest.raises(FloodError):
+        consume(session, user_id=user_id, expert="tarot")
+    # bypass anti-flood
+    usage = session.query(Usage).first()
+    assert usage is not None
+    usage.created_at = datetime.utcnow() - timedelta(seconds=ANTI_FLOOD_SECONDS + 1)
+    session.commit()
+    with pytest.raises(DailyCapError):
+        consume(session, user_id=user_id, expert="tarot")
+
+
+def test_parallelism_limit() -> None:
+    with _track(1):
+        with _track(1):
+            with pytest.raises(ParallelismError):
+                with _track(1):
+                    pass

--- a/app/tests/test_payments.py
+++ b/app/tests/test_payments.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+from aiogram import types
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.sqlite import JSON as SQLITE_JSON
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.core.payments import (
+    PRODUCT_CATALOG,
+    create_order,
+    handle_pre_checkout,
+    handle_successful_payment,
+    send_product_invoice,
+)
+from app.db import models
+from app.db.base import Base
+from app.db.models import Entitlement, Order, User
+
+
+def _setup_session() -> Session:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    models.JSONB = SQLITE_JSON  # type: ignore[attr-defined]
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, future=True)()
+
+
+def _create_user(session: Session) -> User:
+    user = User(id=1, tg_id=1)
+    session.add(user)
+    session.commit()
+    return user
+
+
+def test_send_invoice_uses_xtr_currency() -> None:
+    session = _setup_session()
+    user = _create_user(session)
+    order = create_order(session, user_id=user.id, product_id="pack_3")
+    bot = AsyncMock()
+    asyncio.run(send_product_invoice(bot, chat_id=1, order=order))
+    bot.send_invoice.assert_awaited()
+    args, kwargs = bot.send_invoice.await_args
+    assert kwargs["currency"] == "XTR"
+
+
+def test_pre_checkout_updates_order_status() -> None:
+    session = _setup_session()
+    user = _create_user(session)
+    order = create_order(session, user_id=user.id, product_id="pack_3")
+    query = SimpleNamespace(
+        invoice_payload=str(order.id),
+        answer=AsyncMock(),
+    )
+    asyncio.run(handle_pre_checkout(cast(types.PreCheckoutQuery, query), session))
+    updated = session.get(Order, order.id)
+    assert updated is not None
+    assert updated.status == "pre_checkout"
+    query.answer.assert_awaited_with(ok=True)
+
+
+def test_successful_payment_creates_entitlement() -> None:
+    session = _setup_session()
+    user = _create_user(session)
+    order = create_order(session, user_id=user.id, product_id="pack_3")
+    sp = types.SuccessfulPayment(
+        currency="XTR",
+        total_amount=order.amount_xtr,
+        invoice_payload=str(order.id),
+        telegram_payment_charge_id="tpc",
+        provider_payment_charge_id="ppc",
+    )
+    msg = types.Message(
+        message_id=1,
+        date=datetime.now(),
+        chat=types.Chat(id=1, type="private"),
+        successful_payment=sp,
+    )
+    asyncio.run(handle_successful_payment(msg, session))
+    updated = session.get(Order, order.id)
+    assert updated is not None
+    assert updated.status == "paid"
+    ent = session.query(Entitlement).one()
+    assert ent.quota_total == PRODUCT_CATALOG[order.product].quota


### PR DESCRIPTION
## Summary
- add XTR product catalog and order processing for Stars invoices
- enforce quota, daily cap, flood and parallelism limits with usage tracking
- test payments and limit consumption flows

## Testing
- `ruff check app/core/payments/__init__.py app/core/limits/__init__.py app/tests/test_payments.py app/tests/test_limits.py`
- `mypy --strict app/core/payments/__init__.py app/core/limits/__init__.py app/tests/test_limits.py app/tests/test_payments.py`
- `pytest --cov=app --cov-report=term-missing --cov-fail-under=90`

------
https://chatgpt.com/codex/tasks/task_e_68aae15fd850832fa464004d29fb8603