### PR TITLE
Add S3 storage utilities and PDF generation

### DIFF
--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -1,0 +1,148 @@
+"""S3 storage utilities and PDF generation.
+
+This module provides a small wrapper around the :mod:`minio` client used in
+the project.  It supports uploading images and PDFs to an S3 compatible
+storage (e.g. MinIO) and generating presigned URLs for downloaded files.  HTML
+to PDF conversion is performed with `WeasyPrint`_ if it is available in the
+runtime environment.
+
+The functions enforce a strict 10 MB limit for all uploaded files as required
+by the project specification.
+
+.. _WeasyPrint: https://weasyprint.org/
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import timedelta
+from io import BytesIO
+from typing import Optional, cast
+from uuid import uuid4
+
+from minio import Minio
+
+try:  # pragma: no cover - optional dependency
+    from weasyprint import HTML
+except Exception:  # pragma: no cover - optional dependency
+    HTML = None
+
+
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
+
+
+def _get_env(name: str) -> str:
+    value = os.environ.get(name)
+    if value is None:
+        raise RuntimeError(f"environment variable {name} is not set")
+    return value
+
+
+@dataclass
+class S3Config:
+    endpoint: str
+    access_key: str
+    secret_key: str
+    bucket: str
+    secure: bool = False
+
+    @classmethod
+    def from_env(cls) -> "S3Config":
+        """Load configuration from environment variables."""
+
+        secure = os.environ.get("S3_SECURE", "false").lower() == "true"
+        return cls(
+            endpoint=_get_env("S3_ENDPOINT"),
+            access_key=_get_env("S3_ACCESS_KEY"),
+            secret_key=_get_env("S3_SECRET_KEY"),
+            bucket=_get_env("S3_BUCKET"),
+            secure=secure,
+        )
+
+
+class S3Storage:
+    """Small helper around :class:`minio.Minio` for file uploads."""
+
+    def __init__(
+        self,
+        config: Optional[S3Config] = None,
+        client: Optional[Minio] = None,
+    ) -> None:
+        self.config = config or S3Config.from_env()
+        self.client = client or Minio(
+            self.config.endpoint,
+            access_key=self.config.access_key,
+            secret_key=self.config.secret_key,
+            secure=self.config.secure,
+        )
+
+        # Ensure bucket exists only when we created the client ourselves.  This
+        # avoids network calls in tests where a dummy client is injected.
+        if client is None and not self.client.bucket_exists(self.config.bucket):
+            self.client.make_bucket(self.config.bucket)
+
+    # ------------------------------------------------------------------ utils
+    def _put_bytes(self, data: bytes, object_name: str, content_type: str) -> str:
+        if len(data) > MAX_FILE_SIZE:
+            raise ValueError("file too large")
+
+        stream = BytesIO(data)
+        self.client.put_object(
+            self.config.bucket,
+            object_name,
+            stream,
+            length=len(data),
+            content_type=content_type,
+        )
+        return object_name
+
+    # ----------------------------------------------------------------- public
+    def upload_image(
+        self,
+        data: bytes,
+        content_type: str,
+        object_name: str | None = None,
+    ) -> str:
+        """Upload image bytes to S3 and return the object name."""
+
+        object_name = object_name or f"{uuid4().hex}{_guess_extension(content_type)}"
+        return self._put_bytes(data, object_name, content_type)
+
+    def upload_pdf_from_html(
+        self,
+        html: str,
+        object_name: str | None = None,
+    ) -> str:
+        """Render HTML to PDF and upload to S3."""
+
+        if HTML is None:  # pragma: no cover - defensive
+            raise RuntimeError("WeasyPrint is not available")
+
+        pdf_bytes = HTML(string=html).write_pdf()
+        object_name = object_name or f"{uuid4().hex}.pdf"
+        return self._put_bytes(pdf_bytes, object_name, "application/pdf")
+
+    def generate_presigned_url(
+        self, object_name: str, expires: timedelta | None = None
+    ) -> str:
+        """Generate a presigned download URL for a stored object."""
+
+        seconds = int(expires.total_seconds()) if expires else 3600
+        return cast(
+            str,
+            self.client.presigned_get_object(
+                self.config.bucket, object_name, expires=seconds
+            ),
+        )
+
+
+def _guess_extension(content_type: str) -> str:
+    if content_type == "image/png":
+        return ".png"
+    if content_type in {"image/jpeg", "image/jpg"}:
+        return ".jpg"
+    return ""
+
+
+__all__ = ["S3Storage", "S3Config", "MAX_FILE_SIZE"]

--- a/app/tests/test_storage.py
+++ b/app/tests/test_storage.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.storage import MAX_FILE_SIZE, S3Config, S3Storage
+
+
+class DummyMinio:
+    """Minimal MinIO stub used for tests."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    # Bucket operations -----------------------------------------------------
+    def bucket_exists(self, bucket: str) -> bool:  # pragma: no cover - simple
+        return True
+
+    def make_bucket(self, bucket: str) -> None:  # pragma: no cover - simple
+        return None
+
+    # Object operations -----------------------------------------------------
+    def put_object(
+        self,
+        bucket: str,
+        object_name: str,
+        data: Any,
+        length: int,
+        content_type: str,
+    ) -> None:
+        self.objects[object_name] = data.read()
+
+    def presigned_get_object(self, bucket: str, object_name: str, expires: int) -> str:
+        return f"https://example.com/{bucket}/{object_name}?exp={expires}"
+
+
+def _storage() -> S3Storage:
+    config = S3Config(endpoint="e", access_key="a", secret_key="s", bucket="b")
+    return S3Storage(config=config, client=DummyMinio())
+
+
+def test_upload_image_size_limit() -> None:
+    storage = _storage()
+    small = b"x" * MAX_FILE_SIZE
+    # should succeed
+    storage.upload_image(small, "image/png", object_name="img.png")
+
+    big = b"x" * (MAX_FILE_SIZE + 1)
+    with pytest.raises(ValueError):
+        storage.upload_image(big, "image/png")
+
+
+def test_generate_presigned_url() -> None:
+    storage = _storage()
+    url = storage.generate_presigned_url("foo")
+    assert "foo" in url
+
+
+def test_upload_pdf_from_html(monkeypatch: pytest.MonkeyPatch) -> None:
+    storage = _storage()
+
+    class DummyHTML:
+        def __init__(self, string: str) -> None:
+            self.string = string
+
+        def write_pdf(self) -> bytes:
+            return b"%PDF-1.4"
+
+    monkeypatch.setattr("app.storage.HTML", DummyHTML)
+    name = storage.upload_pdf_from_html("<p>hi</p>")
+    assert name.endswith(".pdf")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ ignore_missing_imports = true
 module = ["swisseph", "matplotlib", "matplotlib.*"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["minio", "minio.*", "weasyprint", "weasyprint.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 addopts = "--cov=app --cov-report=term-missing --cov-fail-under=90"
 testpaths = ["app/tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ Babel
 Pillow
 pyswisseph
 matplotlib
+weasyprint


### PR DESCRIPTION
## Summary
- implement S3Storage helper for uploads, presigned URLs, and HTML-to-PDF with 10MB limit
- add weasyprint dependency and mypy overrides for third-party libraries
- include unit tests for storage helpers

## Testing
- `pre-commit run --files app/storage/__init__.py app/tests/test_storage.py requirements.txt pyproject.toml`


------
https://chatgpt.com/codex/tasks/task_e_68aae4d09f74832fb727ad1d1bb0cdd5