### PR TITLE
Add RU/EN dictionaries and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # TGP_ASTRO
+
+## Launch
+1. Copy `.env.sample` to `.env` and fill secrets.
+2. Install dependencies: `pip install -r requirements.txt`.
+3. Run services: `docker-compose up --build`.
+4. The Telegram webhook is exposed at `/tg/webhook`.
+
+## Deploy
+- Build the Docker image and push to your registry.
+- Configure environment variables and run `docker-compose up -d` on the server.
+- Use `make migrate` for database migrations.
+
+## Assets structure
+```
+assets/
+  tarot/<deck_id>/cards/*.png
+  runes/<set_id>/runes/*.png
+  dreams/lexicon.json
+```
+All assets are validated on startup and indexed in the database.
+
+## Runbook
+- **Webhook errors**: check logs, verify Telegram token, redeploy if needed.
+- **Asset validation failure**: run `make ingest` and inspect `/admin/decks` for details.
+- **High latency**: check worker queue and Redis status, scale workers if required.
+
+## FAQ and Admin panel
+See [docs/FAQ.md](docs/FAQ.md) for adding new decks, runes or lexicons and for admin panel usage.
+The admin panel exposes `/admin/metrics`, `/admin/decks` and optional `/admin/broadcast` endpoints.

--- a/app/experts/assistant/__init__.py
+++ b/app/experts/assistant/__init__.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from datetime import date
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from PIL import Image, ImageDraw, ImageFont
 
 from app.core.compose import save_image
 from app.core.draw import draw_unique
 from app.core.plugins import Plugin
+from app.experts.messages import get_actions, get_cta, get_section_title
 from app.nlp.verifier import Verifier
 from app.nlp.writer import compose_answer
 
@@ -101,16 +102,20 @@ def write(data: dict[str, Any]) -> dict[str, Any]:
     theme = data["facts"]["theme"]
     brief = data["facts"].get("brief", "")
     summary = f"{theme}: {brief}" if brief else theme
-    sections = [{"title": "Request" if locale == "en" else "Запрос", "body_md": theme}]
+    sections = [
+        {
+            "title": get_section_title(PLUGIN_ID, "request", locale),
+            "body_md": theme,
+        }
+    ]
     if brief:
         sections.append(
-            {"title": "Details" if locale == "en" else "Детали", "body_md": brief}
+            {
+                "title": get_section_title(PLUGIN_ID, "details", locale),
+                "body_md": brief,
+            }
         )
-    actions = [
-        "Check the response.",
-        "Ask follow-up questions.",
-        "Apply the suggestions.",
-    ]
+    actions = get_actions(PLUGIN_ID, locale)
     facts = {
         **data["facts"],
         "summary": summary,
@@ -118,11 +123,9 @@ def write(data: dict[str, Any]) -> dict[str, Any]:
         "actions": actions,
     }
     verifier = Verifier()
-    output = cast(
-        dict[str, Any], verifier.ensure_verified(compose_answer, facts, locale)
-    )
-    output["facts"] = data["facts"]
-    return output
+    result = verifier.ensure_verified(compose_answer, facts, locale)
+    result["facts"] = data["facts"]
+    return result
 
 
 def verify(data: dict[str, Any]) -> bool:
@@ -136,7 +139,7 @@ def verify(data: dict[str, Any]) -> bool:
 
 
 def cta(locale: str) -> list[str]:
-    return ["Refine", "New request", "Share"]
+    return get_cta(PLUGIN_ID, locale)
 
 
 plugin = Plugin(

--- a/app/experts/astrology/__init__.py
+++ b/app/experts/astrology/__init__.py
@@ -10,6 +10,7 @@ import matplotlib.pyplot as plt
 import swisseph as swe
 
 from app.core.plugins import Plugin
+from app.experts.messages import get_actions, get_cta, get_disclaimers
 from app.nlp.verifier import Verifier
 from app.nlp.writer import compose_answer
 
@@ -181,14 +182,8 @@ def write(data: dict[str, Any]) -> dict[str, Any]:
     moon = next(e for e in table if e.planet == "Moon")
     summary = f"Sun in {sun.sign}, Moon in {moon.sign}"
     details = "\n".join(f"{e.planet}: {e.sign} {e.degree:.2f}°" for e in table)
-    actions = [
-        "Reflect on these planetary placements.",
-        "Consider how aspects influence your chart.",
-        "Use this insight for self-awareness.",
-    ]
-    disclaimers = []
-    if solar:
-        disclaimers.append("Birth time unknown; chart is calculated for solar noon.")
+    actions = get_actions(PLUGIN_ID, locale)
+    disclaimers = get_disclaimers(PLUGIN_ID, locale) if solar else []
 
     facts = {
         **data["facts"],
@@ -214,7 +209,7 @@ def verify(data: dict[str, Any]) -> bool:
 
 
 def cta(locale: str) -> list[str]:
-    return ["Calculate again", "Share"]
+    return get_cta(PLUGIN_ID, locale)
 
 
 plugin = Plugin(

--- a/app/experts/dreams/__init__.py
+++ b/app/experts/dreams/__init__.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 
 from PIL import Image
 
-from app.core.compose import CardSpec, Layout, compose as compose_cards, save_image
+from app.core.compose import CardSpec, Layout, save_image
+from app.core.compose import compose as compose_cards
 from app.core.plugins import Plugin
+from app.experts.messages import get_actions, get_cta, get_disclaimers
 from app.nlp.verifier import Verifier
 from app.nlp.writer import compose_answer
 
@@ -23,7 +25,7 @@ def form_steps(locale: str) -> list[dict[str, Any]]:
 
 def _load_lexicon(path: Path) -> Dict[str, Any]:
     with path.open("r", encoding="utf-8") as f:
-        return json.load(f)
+        return cast(Dict[str, Any], json.load(f))
 
 
 def prepare(data: dict[str, Any]) -> dict[str, Any]:
@@ -121,24 +123,8 @@ def write(data: dict[str, Any]) -> dict[str, Any]:
         sections.append({"title": name, "body_md": body})
         i += 1
 
-    if locale == "ru":
-        actions = [
-            "Ведите дневник снов.",
-            "Подумайте, какие чувства вызвал сон.",
-            "Поделитесь сном с близким человеком.",
-        ]
-        disclaimers = [
-            "Толкование носит развлекательный характер и не является медицинской помощью."
-        ]
-    else:
-        actions = [
-            "Keep a dream journal.",
-            "Reflect on the feelings in the dream.",
-            "Share the dream with someone you trust.",
-        ]
-        disclaimers = [
-            "This interpretation is for entertainment and not medical advice."
-        ]
+    actions = get_actions(PLUGIN_ID, locale)
+    disclaimers = get_disclaimers(PLUGIN_ID, locale)
 
     verify_facts = {
         **facts,
@@ -163,10 +149,7 @@ def verify(data: dict[str, Any]) -> bool:
 
 
 def cta(locale: str) -> list[str]:
-    return [
-        "Interpret another dream" if locale == "en" else "Расшифровать другой сон",
-        "Share",
-    ]
+    return get_cta(PLUGIN_ID, locale)
 
 
 plugin = Plugin(

--- a/app/experts/lenormand/__init__.py
+++ b/app/experts/lenormand/__init__.py
@@ -12,6 +12,7 @@ from app.core.compose import CardSpec, Layout, save_image
 from app.core.compose import compose as compose_cards
 from app.core.draw import draw_unique
 from app.core.plugins import Plugin
+from app.experts.messages import get_actions, get_cta
 from app.nlp.verifier import Verifier
 from app.nlp.writer import compose_answer
 
@@ -152,11 +153,7 @@ def write(data: dict[str, Any]) -> dict[str, Any]:
     names = [name for name in data["facts"].values()]
     summary = ", ".join(names)
     details = "\n".join(f"{i + 1}. {name}" for i, name in enumerate(names))
-    actions = [
-        "Note the sequence of cards.",
-        "Consider how each card relates to your question.",
-        "Record your insights for later.",
-    ]
+    actions = get_actions(PLUGIN_ID, locale)
 
     facts = {
         **data["facts"],
@@ -180,7 +177,7 @@ def verify(data: dict[str, Any]) -> bool:
 
 
 def cta(locale: str) -> list[str]:
-    return ["Draw again", "Try another spread", "Share"]
+    return get_cta(PLUGIN_ID, locale)
 
 
 plugin = Plugin(

--- a/app/experts/messages.py
+++ b/app/experts/messages.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+ACTIONS: Dict[str, Dict[str, List[str]]] = {
+    "tarot": {
+        "en": [
+            "Reflect on how the cards relate to your question.",
+            "Trust your intuition as you interpret the spread.",
+            "Record your insights for future reference.",
+        ],
+        "ru": [
+            "Подумайте, как карты связаны с вашим вопросом.",
+            "Доверьтесь интуиции, интерпретируя расклад.",
+            "Запишите инсайты для будущего.",
+        ],
+    },
+    "runes": {
+        "en": [
+            "Reflect on how the runes relate to your question.",
+            "Trust your intuition as you interpret their meanings.",
+            "Record your insights for future reference.",
+        ],
+        "ru": [
+            "Подумайте, как руны связаны с вашим вопросом.",
+            "Доверьтесь интуиции при трактовке значения.",
+            "Запишите инсайты для будущего.",
+        ],
+    },
+    "lenormand": {
+        "en": [
+            "Note the sequence of cards.",
+            "Consider how each card relates to your question.",
+            "Record your insights for later.",
+        ],
+        "ru": [
+            "Обратите внимание на порядок карт.",
+            "Подумайте, как каждая карта связана с вашим вопросом.",
+            "Запишите свои мысли для будущего.",
+        ],
+    },
+    "assistant": {
+        "en": [
+            "Check the response.",
+            "Ask follow-up questions.",
+            "Apply the suggestions.",
+        ],
+        "ru": [
+            "Проверьте ответ.",
+            "Задайте уточняющие вопросы.",
+            "Примените предложения.",
+        ],
+    },
+    "copywriter": {
+        "en": [
+            "Outline main points.",
+            "Draft the text.",
+            "Edit and publish.",
+        ],
+        "ru": [
+            "Определите основные тезисы.",
+            "Подготовьте черновик.",
+            "Отредактируйте и опубликуйте.",
+        ],
+    },
+    "dreams": {
+        "en": [
+            "Keep a dream journal.",
+            "Reflect on the feelings in the dream.",
+            "Share the dream with someone you trust.",
+        ],
+        "ru": [
+            "Ведите дневник снов.",
+            "Подумайте, какие чувства вызвал сон.",
+            "Поделитесь сном с близким человеком.",
+        ],
+    },
+    "numerology": {
+        "en": [
+            "Reflect on these numbers.",
+            "Keep a journal.",
+            "Share with a friend.",
+        ],
+        "ru": [
+            "Подумайте над этими числами.",
+            "Ведите дневник.",
+            "Поделитесь с другом.",
+        ],
+    },
+    "astrology": {
+        "en": [
+            "Reflect on these planetary placements.",
+            "Consider how aspects influence your chart.",
+            "Use this insight for self-awareness.",
+        ],
+        "ru": [
+            "Обдумайте эти положения планет.",
+            "Подумайте, как аспекты влияют на вашу карту.",
+            "Используйте это понимание для самопознания.",
+        ],
+    },
+}
+
+CTA: Dict[str, Dict[str, List[str]]] = {
+    "tarot": {
+        "en": ["Draw another card", "Try another spread", "Share"],
+        "ru": ["Дотянуть карту", "Другой спред", "Поделиться"],
+    },
+    "runes": {
+        "en": ["Draw another rune", "Try another spread", "Share"],
+        "ru": ["Дотянуть руну", "Другой расклад", "Поделиться"],
+    },
+    "lenormand": {
+        "en": ["Draw again", "Try another spread", "Share"],
+        "ru": ["Перетянуть", "Другой расклад", "Поделиться"],
+    },
+    "assistant": {
+        "en": ["Refine", "New request", "Share"],
+        "ru": ["Уточнить", "Новый запрос", "Поделиться"],
+    },
+    "copywriter": {
+        "en": ["Clarify", "Try another topic", "Share"],
+        "ru": ["Уточнить", "Другая тема", "Поделиться"],
+    },
+    "dreams": {
+        "en": ["Interpret another dream", "Share"],
+        "ru": ["Расшифровать другой сон", "Поделиться"],
+    },
+    "numerology": {
+        "en": ["Try another date", "Share"],
+        "ru": ["Другую дату", "Поделиться"],
+    },
+    "astrology": {
+        "en": ["Calculate again", "Share"],
+        "ru": ["Рассчитать снова", "Поделиться"],
+    },
+}
+
+DISCLAIMERS: Dict[str, Dict[str, List[str]]] = {
+    "runes": {
+        "en": ["For entertainment purposes only."],
+        "ru": ["Только для развлечения."],
+    },
+    "dreams": {
+        "en": ["This interpretation is for entertainment and not medical advice."],
+        "ru": [
+            "Толкование носит развлекательный характер и не является "
+            "медицинской помощью."
+        ],
+    },
+    "astrology": {
+        "en": ["Birth time unknown; chart is calculated for solar noon."],
+        "ru": ["Время рождения неизвестно; карта построена на полдень."],
+    },
+}
+
+SECTION_TITLES: Dict[str, Dict[str, Dict[str, str]]] = {
+    "assistant": {
+        "request": {"en": "Request", "ru": "Запрос"},
+        "details": {"en": "Details", "ru": "Детали"},
+    },
+    "copywriter": {
+        "theme": {"en": "Theme", "ru": "Тема"},
+        "brief": {"en": "Brief", "ru": "Бриф"},
+    },
+}
+
+
+def get_actions(expert: str, locale: str) -> List[str]:
+    return ACTIONS.get(expert, {}).get(locale, ACTIONS.get(expert, {}).get("en", []))
+
+
+def get_cta(expert: str, locale: str) -> List[str]:
+    return CTA.get(expert, {}).get(locale, CTA.get(expert, {}).get("en", []))
+
+
+def get_disclaimers(expert: str, locale: str) -> List[str]:
+    return DISCLAIMERS.get(expert, {}).get(
+        locale, DISCLAIMERS.get(expert, {}).get("en", [])
+    )
+
+
+def get_section_title(expert: str, section: str, locale: str) -> str:
+    sect = SECTION_TITLES.get(expert, {}).get(section, {})
+    return sect.get(locale, sect.get("en", section))

--- a/app/experts/numerology/__init__.py
+++ b/app/experts/numerology/__init__.py
@@ -10,6 +10,7 @@ from PIL import Image, ImageDraw, ImageFont
 
 from app.core.compose import save_image
 from app.core.plugins import Plugin
+from app.experts.messages import get_actions, get_cta
 from app.nlp.verifier import Verifier
 from app.nlp.writer import compose_answer
 
@@ -42,7 +43,11 @@ def _reduce(n: int) -> int:
 
 
 def _letters_value(
-    name: str, alphabet: Dict[str, int], *, vowels: bool = False, consonants: bool = False
+    name: str,
+    alphabet: Dict[str, int],
+    *,
+    vowels: bool = False,
+    consonants: bool = False,
 ) -> int:
     vowels_set = set("AEIOUY")
     total = 0
@@ -93,9 +98,7 @@ def _calc_challenges(birth: date) -> List[int]:
 
 def _calc_numbers(name: str, birth: date, target: date, locale: str) -> Dict[str, Any]:
     alphabet = _load_alphabet(locale)
-    life_path = _reduce(
-        sum(int(d) for d in birth.strftime("%Y%m%d") if d.isdigit())
-    )
+    life_path = _reduce(sum(int(d) for d in birth.strftime("%Y%m%d") if d.isdigit()))
     expression = _letters_value(name, alphabet)
     soul = _letters_value(name, alphabet, vowels=True)
     personality = _letters_value(name, alphabet, consonants=True)
@@ -242,11 +245,7 @@ def write(data: dict[str, Any]) -> dict[str, Any]:
     for i, val in enumerate(nums["challenges"], start=1):
         sections.append({"title": f"Challenge {i}", "body_md": f"Challenge {i}: {val}"})
     summary = f"Life Path {nums['life_path']}, Expression {nums['expression']}"
-    actions = [
-        "Reflect on these numbers",
-        "Keep a journal",
-        "Share with a friend",
-    ]
+    actions = get_actions(PLUGIN_ID, locale)
     facts: Dict[str, Any] = {k: nums[k] for k in core_keys}
     for i, v in enumerate(nums["pinnacles"], start=1):
         facts[f"pinnacle_{i}"] = v
@@ -272,7 +271,7 @@ def verify(data: dict[str, Any]) -> bool:
 
 
 def cta(locale: str) -> list[str]:
-    return ["Try another date", "Share"]
+    return get_cta(PLUGIN_ID, locale)
 
 
 plugin = Plugin(

--- a/app/experts/runes/__init__.py
+++ b/app/experts/runes/__init__.py
@@ -11,6 +11,7 @@ from PIL import Image
 from app.core.assets import ASSET_CACHE
 from app.core.draw import draw_unique
 from app.core.plugins import Plugin
+from app.experts.messages import get_actions, get_cta, get_disclaimers
 from app.nlp.verifier import Verifier
 from app.nlp.writer import compose_answer
 
@@ -177,12 +178,8 @@ def write(data: dict[str, Any]) -> dict[str, Any]:
         body = f"The {name} rune appears {orientation}."
         sections.append({"title": name, "body_md": body})
 
-    actions = [
-        "Reflect on how the runes relate to your question.",
-        "Trust your intuition as you interpret their meanings.",
-        "Record your insights for future reference.",
-    ]
-    disclaimers = ["For entertainment purposes only."]
+    actions = get_actions(PLUGIN_ID, locale)
+    disclaimers = get_disclaimers(PLUGIN_ID, locale)
 
     verify_facts = {
         **facts,
@@ -207,7 +204,7 @@ def verify(data: dict[str, Any]) -> bool:
 
 
 def cta(locale: str) -> list[str]:
-    return ["Draw another rune", "Try another spread", "Share"]
+    return get_cta(PLUGIN_ID, locale)
 
 
 plugin = Plugin(

--- a/app/experts/tarot/__init__.py
+++ b/app/experts/tarot/__init__.py
@@ -12,6 +12,7 @@ from app.core.compose import CardSpec, Layout, save_image
 from app.core.compose import compose as compose_cards
 from app.core.draw import draw_unique
 from app.core.plugins import Plugin
+from app.experts.messages import get_actions, get_cta
 from app.nlp.verifier import Verifier
 from app.nlp.writer import compose_answer
 
@@ -186,11 +187,7 @@ def write(data: dict[str, Any]) -> dict[str, Any]:
     names = [name for name in data["facts"].values()]
     summary = ", ".join(names)
     details = "\n".join(f"{i + 1}. {name}" for i, name in enumerate(names))
-    actions = [
-        "Reflect on how the cards relate to your question.",
-        "Trust your intuition as you interpret the spread.",
-        "Record your insights for future reference.",
-    ]
+    actions = get_actions(PLUGIN_ID, locale)
 
     facts = {
         **data["facts"],
@@ -214,7 +211,7 @@ def verify(data: dict[str, Any]) -> bool:
 
 
 def cta(locale: str) -> list[str]:
-    return ["Draw another card", "Try another spread", "Share"]
+    return get_cta(PLUGIN_ID, locale)
 
 
 plugin = Plugin(

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,20 @@
+# FAQ
+
+## Loading new decks
+1. Create a directory under `assets/tarot/<deck_id>` containing card images and `deck.json`.
+2. Run `make ingest` or restart the app to validate and index the deck.
+3. Use the admin panel `/admin/decks` to verify the deck appears and passes validation.
+
+## Loading rune sets
+1. Add a folder `assets/runes/<set_id>` with rune images and `set.json`.
+2. Trigger asset ingestion so the new set is validated and stored in the index.
+3. Confirm availability through `/admin/decks`.
+
+## Loading lexicons
+1. For dreams or other NLP modules place the JSON lexicon under `assets/<module>/lexicon.json`.
+2. Restart the service so the parser reloads the lexicon.
+
+## Admin panel
+- Metrics: visit `/admin/metrics` to inspect usage statistics.
+- Decks: `/admin/decks` lists all indexed assets and validation status.
+- Broadcast: `/admin/broadcast` (optional) sends messages to user segments.


### PR DESCRIPTION
## Summary
- centralize interface translations for expert actions, disclaimers and CTAs
- document launch/deploy, asset layout and runbook
- add FAQ for decks, runes, lexicons and admin panel

## Testing
- `pre-commit run --files README.md docs/FAQ.md app/experts/messages.py app/experts/tarot/__init__.py app/experts/runes/__init__.py app/experts/lenormand/__init__.py app/experts/assistant/__init__.py app/experts/copywriter/__init__.py app/experts/dreams/__init__.py app/experts/numerology/__init__.py app/experts/astrology/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68aae89feef0832fb4db20e52dc790ff