### PR TITLE
Add user quota history and tariff storefront

### DIFF
--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
-from aiogram import F, Router
+from datetime import datetime
+
+from aiogram import Bot, F, Router
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import CallbackQuery, Message
 from aiogram.utils.i18n import gettext as _
 
-from .menu import main_menu
+from app.core.payments import create_order, send_product_invoice
+from app.db.models import Entitlement, Usage
+from app.db.session import SessionLocal
+
+from .menu import main_menu, tariffs_menu
 
 router = Router()
 
@@ -35,25 +41,83 @@ async def cmd_help(message: Message) -> None:
     )
 
 
-@router.message(Command("profile"))
-async def cmd_profile(message: Message) -> None:
-    await message.answer(_("Profile: no data available."))
+def _history_and_quota(user_id: int) -> tuple[int, list[str]]:
+    """Retrieve remaining quota and last usage records."""
+
+    with SessionLocal() as session:
+        entitlement = (
+            session.query(Entitlement)
+            .filter(Entitlement.user_id == user_id, Entitlement.status == "active")
+            .order_by(Entitlement.created_at.desc())
+            .first()
+        )
+        quota = 0
+        if entitlement and (
+            not entitlement.expires_at
+            or entitlement.expires_at > datetime.utcnow()
+        ):
+            quota = entitlement.quota_left
+        usages = (
+            session.query(Usage)
+            .filter(Usage.user_id == user_id)
+            .order_by(Usage.created_at.desc())
+            .limit(5)
+            .all()
+        )
+    lines = [f"{u.created_at:%Y-%m-%d %H:%M} — {u.expert} (-{u.cost})" for u in usages]
+    return quota, lines
 
 
-@router.message(Command("history"))
+async def _send_history(message: Message, user_id: int) -> None:
+    quota, lines = _history_and_quota(user_id)
+    if lines:
+        history_text = "\n".join(lines)
+    else:
+        history_text = _("No usage yet.")
+    text = _("Your remaining quota: {quota}").format(quota=quota)
+    text += "\n" + _("Usage history:") + "\n" + history_text
+    await message.answer(text)
+
+
+@router.message(MainState.menu, Command("profile"))
+@router.message(MainState.menu, Command("history"))
 async def cmd_history(message: Message) -> None:
-    await message.answer(_("History: no records."))
+    await _send_history(message, message.from_user.id)
 
 
-@router.callback_query(F.data == "profile")
+@router.callback_query(MainState.menu, F.data == "profile")
 async def cb_profile(callback: CallbackQuery) -> None:
     if callback.message:
-        await callback.message.answer(_("Profile: no data available."))
+        await _send_history(callback.message, callback.from_user.id)
     await callback.answer()
 
 
-@router.callback_query(F.data == "tariffs")
+@router.callback_query(MainState.menu, F.data == "tariffs")
 async def cb_tariffs(callback: CallbackQuery) -> None:
     if callback.message:
-        await callback.message.answer(_("History: no records."))
+        await callback.message.answer(
+            _("Available tariff plans:"), reply_markup=tariffs_menu()
+        )
+    await callback.answer()
+
+
+@router.callback_query(MainState.menu, F.data.startswith("buy:"))
+async def cb_buy(callback: CallbackQuery, bot: Bot) -> None:
+    product_id = callback.data.split(":", 1)[1]
+    with SessionLocal() as session:
+        order = create_order(
+            session, user_id=callback.from_user.id, product_id=product_id
+        )
+    await send_product_invoice(bot, callback.from_user.id, order)
+    await callback.answer()
+
+
+@router.callback_query(MainState.menu, F.data == "back:main")
+async def cb_back_main(callback: CallbackQuery, state: FSMContext) -> None:
+    if callback.message:
+        await callback.message.answer(
+            _("Welcome! Use the menu below to choose an expert or view tariffs."),
+            reply_markup=main_menu(),
+        )
+    await state.set_state(MainState.menu)
     await callback.answer()

--- a/app/bot/locales/en/LC_MESSAGES/bot.po
+++ b/app/bot/locales/en/LC_MESSAGES/bot.po
@@ -44,3 +44,30 @@ msgstr "💎 Premium/Payment"
 
 msgid "👤 Profile/History"
 msgstr "👤 Profile/History"
+
+msgid "No usage yet."
+msgstr "No usage yet."
+
+msgid "Your remaining quota: {quota}"
+msgstr "Your remaining quota: {quota}"
+
+msgid "Usage history:"
+msgstr "Usage history:"
+
+msgid "Available tariff plans:"
+msgstr "Available tariff plans:"
+
+msgid "⬅️ Back"
+msgstr "⬅️ Back"
+
+msgid "3 Requests"
+msgstr "3 Requests"
+
+msgid "10 Requests"
+msgstr "10 Requests"
+
+msgid "Unlimited 30d"
+msgstr "Unlimited 30d"
+
+msgid "Subscription 30d"
+msgstr "Subscription 30d"

--- a/app/bot/locales/ru/LC_MESSAGES/bot.po
+++ b/app/bot/locales/ru/LC_MESSAGES/bot.po
@@ -44,3 +44,30 @@ msgstr "💎 Премиум/Оплата"
 
 msgid "👤 Profile/History"
 msgstr "👤 Профиль/История"
+
+msgid "No usage yet."
+msgstr "История пуста."
+
+msgid "Your remaining quota: {quota}"
+msgstr "Ваш остаток квоты: {quota}"
+
+msgid "Usage history:"
+msgstr "История запросов:"
+
+msgid "Available tariff plans:"
+msgstr "Доступные тарифы:"
+
+msgid "⬅️ Back"
+msgstr "⬅️ Назад"
+
+msgid "3 Requests"
+msgstr "3 запроса"
+
+msgid "10 Requests"
+msgstr "10 запросов"
+
+msgid "Unlimited 30d"
+msgstr "Безлимит на 30 дней"
+
+msgid "Subscription 30d"
+msgstr "Подписка 30 дней"

--- a/app/bot/menu.py
+++ b/app/bot/menu.py
@@ -4,6 +4,8 @@ from aiogram.types import InlineKeyboardMarkup
 from aiogram.utils.i18n import gettext as _
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
+from app.core.payments import PRODUCT_CATALOG
+
 EXPERT_BUTTONS = [
     ("🃏 Tarot", "expert:tarot"),
     ("♣ Lenormand", "expert:lenormand"),
@@ -26,4 +28,17 @@ def main_menu() -> InlineKeyboardMarkup:
     builder.button(text=_(TARIFF_BUTTON[0]), callback_data=TARIFF_BUTTON[1])
     builder.button(text=_(PROFILE_BUTTON[0]), callback_data=PROFILE_BUTTON[1])
     builder.adjust(2)
+    return builder.as_markup()
+
+
+def tariffs_menu() -> InlineKeyboardMarkup:
+    """Inline keyboard with available tariff products."""
+
+    builder = InlineKeyboardBuilder()
+    for product in PRODUCT_CATALOG.values():
+        builder.button(
+            text=_(product.title), callback_data=f"buy:{product.product_id}"
+        )
+    builder.button(text=_("⬅️ Back"), callback_data="back:main")
+    builder.adjust(1)
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- show remaining quota and recent usage history
- expose tariff products with purchase CTAs and FSM integration
- localize history and tariff messages in RU/EN

## Testing
- `ruff check app/bot/handlers.py app/bot/menu.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aaf65ad5b0832f9cfe3323b2572dac