### PR TITLE
Add tariffs display and payment refund support

### DIFF
--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -9,7 +9,7 @@ from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import CallbackQuery, Message
 from aiogram.utils.i18n import gettext as _
 
-from app.core.payments import create_order, send_product_invoice
+from app.core.payments import PRODUCT_CATALOG, create_order, send_product_invoice
 from app.db.models import Entitlement, Usage
 from app.db.session import SessionLocal
 
@@ -95,9 +95,14 @@ async def cb_profile(callback: CallbackQuery) -> None:
 @router.callback_query(MainState.menu, F.data == "tariffs")
 async def cb_tariffs(callback: CallbackQuery) -> None:
     if callback.message:
-        await callback.message.answer(
-            _("Available tariff plans:"), reply_markup=tariffs_menu()
-        )
+        lines = [
+            _("{title}: {amount} XTR").format(
+                title=product.title, amount=product.amount_xtr
+            )
+            for product in PRODUCT_CATALOG.values()
+        ]
+        text = _("Available tariff plans:") + "\n" + "\n".join(lines)
+        await callback.message.answer(text, reply_markup=tariffs_menu())
     await callback.answer()
 
 

--- a/app/tests/test_payments.py
+++ b/app/tests/test_payments.py
@@ -16,6 +16,7 @@ from app.core.payments import (
     create_order,
     handle_pre_checkout,
     handle_successful_payment,
+    refund_order,
     send_product_invoice,
 )
 from app.db import models
@@ -86,3 +87,31 @@ def test_successful_payment_creates_entitlement() -> None:
     assert updated.status == "paid"
     ent = session.query(Entitlement).one()
     assert ent.quota_total == PRODUCT_CATALOG[order.product].quota
+
+
+def test_refund_order_cancels_entitlement() -> None:
+    session = _setup_session()
+    user = _create_user(session)
+    order = create_order(session, user_id=user.id, product_id="pack_3")
+    sp = types.SuccessfulPayment(
+        currency="XTR",
+        total_amount=order.amount_xtr,
+        invoice_payload=str(order.id),
+        telegram_payment_charge_id="tpc",
+        provider_payment_charge_id="ppc",
+    )
+    msg = types.Message(
+        message_id=1,
+        date=datetime.now(),
+        chat=types.Chat(id=1, type="private"),
+        successful_payment=sp,
+    )
+    asyncio.run(handle_successful_payment(msg, session))
+    ent = session.query(Entitlement).one()
+    refund_order(session, order.id)
+    updated_order = session.get(Order, order.id)
+    assert updated_order is not None
+    assert updated_order.status == "refunded"
+    updated_ent = session.get(Entitlement, ent.id)
+    assert updated_ent is not None
+    assert updated_ent.status == "cancelled"


### PR DESCRIPTION
## Summary
- show available tariff products with prices on tariffs callback
- support refunding orders and cancelling entitlements
- cover payment and refund flows with tests

## Testing
- `ruff check app/bot/handlers.py app/core/payments/__init__.py app/tests/test_payments.py`
- `pytest app/tests/test_payments.py -q --cov=app/core/payments --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68aafed0e8cc832f8e8311e5c266f445