### PR TITLE
refactor: add env config with validation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,35 +1,35 @@
 # Application
-APP_HOST=0.0.0.0
-APP_PORT=8000
+APP_HOST=<host>
+APP_PORT=<port>
 
 # Database
-DB_HOST=db
-DB_PORT=5432
-DB_NAME=app
-DB_USER=app
-DB_PASSWORD=app
+DB_HOST=<db_host>
+DB_PORT=<db_port>
+DB_NAME=<db_name>
+DB_USER=<db_user>
+DB_PASSWORD=<db_password>
 DATABASE_URL=postgresql+psycopg://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME
 
 # Redis
-REDIS_HOST=redis
-REDIS_PORT=6379
-REDIS_DB=0
+REDIS_HOST=<redis_host>
+REDIS_PORT=<redis_port>
+REDIS_DB=<redis_db>
 
 # MinIO
-MINIO_ENDPOINT=minio:9000
-MINIO_ROOT_USER=minio
-MINIO_ROOT_PASSWORD=minio123
-MINIO_BUCKET=app
+MINIO_ENDPOINT=<minio_endpoint>
+MINIO_ROOT_USER=<minio_root_user>
+MINIO_ROOT_PASSWORD=<minio_root_password>
+MINIO_BUCKET=<minio_bucket>
 
 # Telegram
-TELEGRAM_TOKEN=
-TELEGRAM_WEBHOOK_URL=
+TELEGRAM_TOKEN=<telegram_token>
+TELEGRAM_WEBHOOK_URL=<telegram_webhook_url>
 
 # Stars
-STARS_API_KEY=
+STARS_API_KEY=<stars_api_key>
 
 # S3
-S3_ENDPOINT=
-S3_ACCESS_KEY=
-S3_SECRET_KEY=
-S3_BUCKET=
+S3_ENDPOINT=<s3_endpoint>
+S3_ACCESS_KEY=<s3_access_key>
+S3_SECRET_KEY=<s3_secret_key>
+S3_BUCKET=<s3_bucket>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict"]
-        additional_dependencies: ["fastapi", "pydantic", "SQLAlchemy", "alembic"]
+        additional_dependencies: ["fastapi", "pydantic", "pydantic-settings", "SQLAlchemy", "alembic"]
   - repo: local
     hooks:
       - id: pytest

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment."""
+
+    app_host: str
+    app_port: int
+    db_host: str
+    db_port: int
+    db_name: str
+    db_user: str
+    db_password: str
+    database_url: str
+    redis_host: str
+    redis_port: int
+    redis_db: int
+    minio_endpoint: str
+    minio_root_user: str
+    minio_root_password: str
+    minio_bucket: str
+    telegram_token: str
+    telegram_webhook_url: str | None = None
+    stars_api_key: str | None = None
+    s3_endpoint: str | None = None
+    s3_access_key: str | None = None
+    s3_secret_key: str | None = None
+    s3_bucket: str | None = None
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return application settings, logging presence of variables."""
+
+    settings = Settings()  # type: ignore[call-arg]
+    for name, value in settings.model_dump().items():
+        logger.info(
+            "Environment variable %s %s",
+            name.upper(),
+            "set" if value else "missing",
+        )
+    return settings

--- a/app/db/migrations/env.py
+++ b/app/db/migrations/env.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import os
 from logging.config import fileConfig
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
+
+from app.config import get_settings
 
 # Import models for metadata registration
 from app.db import models  # noqa: F401
@@ -15,9 +16,8 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-DATABASE_URL = os.getenv("DATABASE_URL")
-if DATABASE_URL:
-    config.set_main_option("sqlalchemy.url", DATABASE_URL)
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", settings.database_url)
 
 target_metadata = Base.metadata
 

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import os
 from typing import Generator
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+psycopg://app:app@db:5432/app")
+from app.config import get_settings
 
-engine = create_engine(DATABASE_URL, future=True)
+settings = get_settings()
+engine = create_engine(settings.database_url, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     env_file:
       - .env
     ports:
-      - "${APP_PORT:-8000}:8000"
+      - "${APP_PORT:-<app_port>}:8000"
     depends_on:
       - db
       - redis
@@ -28,9 +28,9 @@ services:
   db:
     image: postgres:15
     environment:
-      POSTGRES_DB: ${DB_NAME:-app}
-      POSTGRES_USER: ${DB_USER:-app}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-app}
+      POSTGRES_DB: ${DB_NAME:-<db_name>}
+      POSTGRES_USER: ${DB_USER:-<db_user>}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-<db_password>}
     ports:
       - "5432:5432"
     volumes:
@@ -43,8 +43,8 @@ services:
     image: minio/minio
     command: server /data --console-address ':9001'
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minio}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minio123}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-<minio_root_user>}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-<minio_root_password>}
     ports:
       - "9000:9000"
       - "9001:9001"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ psycopg[binary]
 minio
 SQLAlchemy>=2.0
 alembic
+pydantic-settings
 Babel
 Pillow
 pyswisseph


### PR DESCRIPTION
## Summary
- sanitize sample env and docker-compose with placeholders
- add strict env settings module and use across app
- update tooling for pydantic-settings

## Testing
- `ruff.....................................................................Passed`
- `black....................................................................Passed`
- `mypy.....................................................................Failed`
- `pytest...................................................................Passed`


------
https://chatgpt.com/codex/tasks/task_e_68aaffecaea0832fbe7ab4ab4885041a