### PR TITLE
refactor: rename sample test assets

### DIFF
--- a/app/tests/test_assets_loader.py
+++ b/app/tests/test_assets_loader.py
@@ -29,13 +29,13 @@ def _setup_session() -> Session:
 def test_load_assets(tmp_path: Path) -> None:
     ASSET_CACHE.clear()
     assets_root = tmp_path
-    deck_dir = assets_root / "tarot" / "sample"
+    deck_dir = assets_root / "tarot" / "testdeck"
     cards_dir = deck_dir / "cards"
     cards_dir.mkdir(parents=True)
     _create_image(deck_dir / "back.png")
     _create_image(cards_dir / "0.png")
     manifest = {
-        "deck_id": "sample",
+        "deck_id": "testdeck",
         "name": {"en": "Sample", "ru": "Пример"},
         "type": "tarot",
         "image": {
@@ -59,7 +59,7 @@ def test_load_assets(tmp_path: Path) -> None:
     load_assets(assets_root, session)
     decks = session.query(Deck).all()
     assert len(decks) == 1
-    assert "sample" in ASSET_CACHE
+    assert "testdeck" in ASSET_CACHE
     assert (deck_dir / "thumbs" / "0.png").exists()
     assert (deck_dir / "thumbs" / "back.png").exists()
 

--- a/app/tests/test_e2e_experts.py
+++ b/app/tests/test_e2e_experts.py
@@ -29,21 +29,27 @@ def _create_image(path: Path, size: tuple[int, int] = (200, 300)) -> None:
 
 
 @pytest.fixture(scope="module")
-def session_and_assets(tmp_path_factory: pytest.TempPathFactory) -> tuple[Session, Path]:
+def session_and_assets(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> tuple[Session, Path]:
     tmp_assets = tmp_path_factory.mktemp("assets")
 
     # Tarot deck
-    tarot_dir = tmp_assets / "tarot" / "tarot_sample"
+    tarot_dir = tmp_assets / "tarot" / "tarot_testdeck"
     tarot_cards = tarot_dir / "cards"
     tarot_cards.mkdir(parents=True)
     _create_image(tarot_dir / "back.png", size=(300, 500))
     for i in range(3):
         _create_image(tarot_cards / f"{i}.png", size=(300, 500))
     tarot_manifest = {
-        "deck_id": "tarot_sample",
+        "deck_id": "tarot_testdeck",
         "name": {"en": "Sample"},
         "type": "tarot",
-        "image": {"aspect_ratio": "3:5", "allow_reversed": True, "default_back": "back.png"},
+        "image": {
+            "aspect_ratio": "3:5",
+            "allow_reversed": True,
+            "default_back": "back.png",
+        },
         "cards": [
             {
                 "key": f"c{i}",
@@ -59,14 +65,14 @@ def session_and_assets(tmp_path_factory: pytest.TempPathFactory) -> tuple[Sessio
     (tarot_dir / "deck.json").write_text(json.dumps(tarot_manifest), encoding="utf-8")
 
     # Lenormand deck
-    leno_dir = tmp_assets / "lenormand" / "leno_sample"
+    leno_dir = tmp_assets / "lenormand" / "leno_testdeck"
     leno_cards = leno_dir / "cards"
     leno_cards.mkdir(parents=True)
     _create_image(leno_dir / "back.png", size=(300, 500))
     for i in range(3):
         _create_image(leno_cards / f"{i}.png", size=(300, 500))
     leno_manifest = {
-        "deck_id": "leno_sample",
+        "deck_id": "leno_testdeck",
         "name": {"en": "Sample"},
         "type": "lenormand",
         "image": {"aspect_ratio": "3:5", "default_back": "back.png"},
@@ -82,17 +88,21 @@ def session_and_assets(tmp_path_factory: pytest.TempPathFactory) -> tuple[Sessio
     (leno_dir / "deck.json").write_text(json.dumps(leno_manifest), encoding="utf-8")
 
     # Runes set
-    runes_dir = tmp_assets / "runes" / "runes_sample"
+    runes_dir = tmp_assets / "runes" / "runes_testdeck"
     runes_items = runes_dir / "runes"
     runes_items.mkdir(parents=True)
     _create_image(runes_dir / "back.png", size=(200, 200))
     for i in range(3):
         _create_image(runes_items / f"{i}.png", size=(200, 200))
     runes_manifest = {
-        "set_id": "runes_sample",
+        "set_id": "runes_testdeck",
         "name": {"en": "Sample"},
         "type": "runes",
-        "image": {"aspect_ratio": "1:1", "allow_reversed": True, "default_back": "back.png"},
+        "image": {
+            "aspect_ratio": "1:1",
+            "allow_reversed": True,
+            "default_back": "back.png",
+        },
         "runes": [
             {
                 "key": f"r{i}",
@@ -129,12 +139,25 @@ def session_and_assets(tmp_path_factory: pytest.TempPathFactory) -> tuple[Sessio
 
 
 EXPERT_CASES = [
-    (tarot.plugin, {"deck_id": "tarot_sample", "spread_id": "tarot_three_ppf", "question": "Q"}),
-    (lenormand.plugin, {"deck_id": "leno_sample", "spread_id": "leno_three_line", "question": "Q"}),
-    (runes.plugin, {"set_id": "runes_sample", "spread_id": "runes_one", "question": "Q"}),
+    (
+        tarot.plugin,
+        {"deck_id": "tarot_testdeck", "spread_id": "tarot_three_ppf", "question": "Q"},
+    ),
+    (
+        lenormand.plugin,
+        {"deck_id": "leno_testdeck", "spread_id": "leno_three_line", "question": "Q"},
+    ),
+    (
+        runes.plugin,
+        {"set_id": "runes_testdeck", "spread_id": "runes_one", "question": "Q"},
+    ),
     (
         numerology.plugin,
-        {"full_name": "John Doe", "birth_date": "2000-01-02", "target_date": "2024-01-01"},
+        {
+            "full_name": "John Doe",
+            "birth_date": "2000-01-02",
+            "target_date": "2024-01-01",
+        },
     ),
     (
         astrology.plugin,

--- a/app/tests/test_runes_plugin.py
+++ b/app/tests/test_runes_plugin.py
@@ -26,14 +26,14 @@ def _setup_session() -> Session:
 
 def test_runes_pipeline(tmp_path: Path) -> None:
     ASSET_CACHE.clear()
-    set_dir = tmp_path / "runes" / "sample"
+    set_dir = tmp_path / "runes" / "testdeck"
     runes_dir = set_dir / "runes"
     runes_dir.mkdir(parents=True)
     _create_image(set_dir / "back.png")
     for i in range(5):
         _create_image(runes_dir / f"{i}.png")
     manifest = {
-        "set_id": "sample",
+        "set_id": "testdeck",
         "name": {"en": "Sample", "ru": "Пример"},
         "type": "runes",
         "image": {
@@ -56,7 +56,7 @@ def test_runes_pipeline(tmp_path: Path) -> None:
     load_assets(tmp_path, session)
 
     params = {
-        "set_id": "sample",
+        "set_id": "testdeck",
         "spread_id": "runes_five_cross",
         "user_id": 42,
         "draw_date": date(2024, 1, 1),
@@ -68,7 +68,7 @@ def test_runes_pipeline(tmp_path: Path) -> None:
     prep2 = runes.prepare(params)
     assert prep1["runes"] == prep2["runes"]
 
-    conf = ASSET_CACHE["sample"]["config"]
+    conf = ASSET_CACHE["testdeck"]["config"]
     by_key = {r["key"]: r for r in conf["runes"]}
     assert any(r["reversed"] for r in prep1["runes"])
     for r in prep1["runes"]:

--- a/app/tests/test_tarot_plugin.py
+++ b/app/tests/test_tarot_plugin.py
@@ -28,7 +28,7 @@ def _setup_session() -> Session:
 
 def test_tarot_pipeline(tmp_path: Path) -> None:
     ASSET_CACHE.clear()
-    deck_dir = tmp_path / "tarot" / "sample"
+    deck_dir = tmp_path / "tarot" / "testdeck"
     cards_dir = deck_dir / "cards"
     cards_dir.mkdir(parents=True)
     _create_image(deck_dir / "back.png")
@@ -36,7 +36,7 @@ def test_tarot_pipeline(tmp_path: Path) -> None:
     for i in range(3):
         _create_image(cards_dir / f"{i}.png")
     manifest = {
-        "deck_id": "sample",
+        "deck_id": "testdeck",
         "name": {"en": "Sample", "ru": "Пример"},
         "type": "tarot",
         "image": {
@@ -61,7 +61,7 @@ def test_tarot_pipeline(tmp_path: Path) -> None:
     load_assets(tmp_path, session)
 
     params = {
-        "deck_id": "sample",
+        "deck_id": "testdeck",
         "spread_id": "tarot_three_ppf",
         "user_id": 42,
         "draw_date": date(2024, 1, 1),


### PR DESCRIPTION
## Summary
- replace `sample` with `testdeck` in test asset paths and manifests

## Testing
- `ruff check app/tests`
- `black app/tests`
- `mypy --strict app/tests` *(fails: Cannot find implementation or library stub for module named `pydantic_settings`)*
- `pytest` *(fails: missing opentelemetry and Settings validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab16b26e18832fb1660e1ce5fe0053